### PR TITLE
Remove backup blob from memory after download

### DIFF
--- a/demo-web/src/Filesystem.js
+++ b/demo-web/src/Filesystem.js
@@ -31,6 +31,7 @@ const backupSite = async () => {
 	const link = document.createElement('a');
 	link.href = URL.createObjectURL(blob);
 	link.click();
+	URL.revokeObjectURL(link.href);
 };
 
 const restoreSite = async ({fileInput}) => {


### PR DESCRIPTION
Prevent backup archive blob from persisting in memory until leaving demo

I was reading https://javascript.info/blob and saw:

> The mapping is automatically cleared on document unload, so Blob objects are freed then. But if an app is long-living, then that doesn’t happen soon.
> 
> So if we create a URL, that Blob will hang in memory, even if not needed any more.
> 
> URL.revokeObjectURL(url) removes the reference from the internal mapping, thus allowing the Blob to be deleted (if there are no other references), and the memory to be freed.