### PR TITLE
Append url.search to originalPath for requests

### DIFF
--- a/source/PhpCgiBase.js
+++ b/source/PhpCgiBase.js
@@ -376,6 +376,9 @@ export class PhpCgiBase
 			{
 				originalPath += '/'
 			}
+			else {
+				originalPath += url.search
+			}
 
 			// Rewrite to index
 			path = docroot + '/index.php';

--- a/source/PhpCgiBase.js
+++ b/source/PhpCgiBase.js
@@ -376,13 +376,14 @@ export class PhpCgiBase
 			{
 				originalPath += '/'
 			}
-			else {
-				originalPath += url.search
-			}
 
 			// Rewrite to index
 			path = docroot + '/index.php';
 		}
+
+		// Ensure query parameters are preserved.
+		originalPath += url.search
+		
 
 		if(this.maxRequestAge > 0 && Date.now() - requestTimes.get(request) > this.maxRequestAge)
 		{


### PR DESCRIPTION
fixes #60 

tested with PhpCgiNode with paths:

- `/cgi/drupal/query.php?langcode=en&profile=standard`
- `/cgi/drupal/` (entrypoint)

this unblocked the interactive/UI installer for Drupal. We couldn't get to the "Requirements" warning form, because submitting the previous form lost query params

<img width="1177" alt="Screenshot 2024-08-23 at 11 00 34 PM" src="https://github.com/user-attachments/assets/f8ad2e7f-ea44-489e-a8cf-70eee74eac1c">
