### PR TITLE
DRAFT: Add tag attribute for binding PhpWeb instance to window

### DIFF
--- a/source/php-tags.mjs
+++ b/source/php-tags.mjs
@@ -126,6 +126,20 @@ const runPhpScriptTag = async (element) => {
 		canvas: scope.canvas,
 	});
 
+	// Option 1:
+
+	// Allow binding php into window via attribute data-bind-php-window='true'
+	// if(element.getAttribute('data-bind-php-window') === 'true'){
+	// 	window.php = php;
+	// }
+
+	// Option 2:
+
+	// Improved by allowing specific window binding name to avoid naming collisions
+	if(element.getAttribute('data-php-bind-window-as')){
+		window[element.getAttribute('data-php-bind-window-as')] = php;
+	}
+
 	php.inputString(input);
 
 	const outListener = event => {


### PR DESCRIPTION
Allows interactive debugging in browser console after page load which is not possible with the tag evaluation method as far as I understand.

Option 1 would simply look for "true" value and add binding `window.php` (available in browser console as `php`), option 2 allows user to specify binding name for avoiding naming conflicts e.g.
  
```
<script 
  type="text/php"
  data-stdout="div#output" data-stderr="pre#error"
  data-php-bind-window-as='wasmphp'>
```

Afterwards the instance can be called from JS console to inspect/modify filesystem contents `await wasmphp.readdir('/preload/')`, loaded classes `await wasmphp.run('<?php echo print_r(get_declared_classes());')` and so on.

The build / CI setup is foreign still, tested the patch locally on npm `0.0.9-alpha-32`. Neater alternative solutions are welcome and attribute naming suggestions if this is generally a good idea.