### PR TITLE
Add support for preloading files in nested directories

### DIFF
--- a/source/PhpBase.js
+++ b/source/PhpBase.js
@@ -83,6 +83,21 @@ export class PhpBase extends EventTarget
 				php.FS.mkdir('/preload');
 			}
 
+			// Make sure folder structure exists before preloading files
+			files.forEach(fileDef => {
+			    const segments = fileDef.parent.split('/');
+			    let currentPath = '';
+			    for (const segment of segments) {
+			        if (!segment) continue;
+			
+			        currentPath += segment + '/';
+			        if (!php.FS.analyzePath(currentPath).exists) {
+			            console.log("create dir " + currentPath);
+			            php.FS.mkdir(currentPath);
+			        }
+			    }
+			});
+			
 			await Promise.all(files.concat(extraFiles).map(
 				fileDef => new Promise(accept => php.FS.createPreloadedFile(
 					fileDef.parent,


### PR DESCRIPTION
Allow `PhpWeb` constructor's `files` parameter and tag attribute `data-files` to preload files with nested directory structure.

This way e.g. Composer's `vendor` directory can be preloaded as a single JSON object.