### PR TITLE
Update Emscripten 6 dynamic library build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 docs/* -diff
 demo-web/public/* -diff
+patch/*.patch whitespace=-blank-at-eol

--- a/.github/bin/retry-download.sh
+++ b/.github/bin/retry-download.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MAX_ATTEMPTS="${DOWNLOAD_RETRY_ATTEMPTS:-5}"
+DELAY_SECONDS="${DOWNLOAD_RETRY_DELAY_SECONDS:-5}"
+
+if [[ ! "${MAX_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]]; then
+	echo "DOWNLOAD_RETRY_ATTEMPTS must be a positive integer: ${MAX_ATTEMPTS}" >&2
+	exit 2
+fi
+
+if [[ ! "${DELAY_SECONDS}" =~ ^[0-9]+$ ]]; then
+	echo "DOWNLOAD_RETRY_DELAY_SECONDS must be a non-negative integer: ${DELAY_SECONDS}" >&2
+	exit 2
+fi
+
+if (( $# != 2 )); then
+	echo "usage: retry-download.sh <url> <output-file>" >&2
+	exit 2
+fi
+
+URL="$1"
+OUTPUT_FILE="$2"
+PART_FILE="${OUTPUT_FILE}.part.$$"
+trap 'rm -f "${PART_FILE}"' EXIT
+
+attempt=1
+delay="${DELAY_SECONDS}"
+
+while true; do
+	echo "download attempt ${attempt}/${MAX_ATTEMPTS}: ${URL}" >&2
+	rm -f "${PART_FILE}"
+
+	set +e
+	curl \
+		--connect-timeout 20 \
+		--fail \
+		--location \
+		--max-time 120 \
+		--output "${PART_FILE}" \
+		--show-error \
+		--silent \
+		"${URL}"
+	curl_status=$?
+	set -e
+
+	if (( curl_status == 0 )); then
+		mv "${PART_FILE}" "${OUTPUT_FILE}"
+		exit 0
+	fi
+
+	if (( attempt >= MAX_ATTEMPTS )); then
+		echo "download failed after ${attempt} attempts (curl exit ${curl_status})" >&2
+		exit "${curl_status}"
+	fi
+
+	echo "download failed (curl exit ${curl_status}); retrying in ${delay} seconds" >&2
+	sleep "${delay}"
+	attempt=$((attempt + 1))
+	delay=$((delay * 2))
+done

--- a/.github/bin/retry-embuilder.sh
+++ b/.github/bin/retry-embuilder.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MAX_ATTEMPTS="${EMBUILDER_RETRY_ATTEMPTS:-5}"
+DELAY_SECONDS="${EMBUILDER_RETRY_DELAY_SECONDS:-5}"
+
+if [[ ! "${MAX_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]]; then
+	echo "EMBUILDER_RETRY_ATTEMPTS must be a positive integer: ${MAX_ATTEMPTS}" >&2
+	exit 2
+fi
+
+if [[ ! "${DELAY_SECONDS}" =~ ^[0-9]+$ ]]; then
+	echo "EMBUILDER_RETRY_DELAY_SECONDS must be a non-negative integer: ${DELAY_SECONDS}" >&2
+	exit 2
+fi
+
+if (( $# == 0 )); then
+	echo "usage: retry-embuilder.sh <embuilder-argument> [...]" >&2
+	exit 2
+fi
+
+TRANSIENT_ERROR_PATTERN='RemoteDisconnected|Remote end closed connection|HTTP Error (408|425|429|5[0-9][0-9])|Connection(Reset|Aborted|Refused)Error|TimeoutError|timed out|Temporary failure in name resolution|Name or service not known|IncompleteRead|urlopen error|UNEXPECTED_EOF_WHILE_READING'
+LOG_FILE="$(mktemp)"
+trap 'rm -f "${LOG_FILE}"' EXIT
+
+attempt=1
+delay="${DELAY_SECONDS}"
+
+while true; do
+	echo "embuilder attempt ${attempt}/${MAX_ATTEMPTS}: embuilder $*" >&2
+	: > "${LOG_FILE}"
+
+	set +e
+	embuilder "$@" 2>&1 | tee "${LOG_FILE}"
+	statuses=("${PIPESTATUS[@]}")
+	set -e
+
+	embuilder_status="${statuses[0]}"
+	tee_status="${statuses[1]}"
+
+	if (( tee_status != 0 )); then
+		echo "could not capture embuilder output (tee exited ${tee_status})" >&2
+		exit "${tee_status}"
+	fi
+
+	if (( embuilder_status == 0 )); then
+		exit 0
+	fi
+
+	if ! grep -Eiq "${TRANSIENT_ERROR_PATTERN}" "${LOG_FILE}"; then
+		echo "embuilder failed with a non-retryable error (exit ${embuilder_status})" >&2
+		exit "${embuilder_status}"
+	fi
+
+	if (( attempt >= MAX_ATTEMPTS )); then
+		echo "embuilder failed after ${attempt} attempts (exit ${embuilder_status})" >&2
+		exit "${embuilder_status}"
+	fi
+
+	echo "transient embuilder download failure; retrying in ${delay} seconds" >&2
+	sleep "${delay}"
+	attempt=$((attempt + 1))
+	delay=$((delay * 2))
+done

--- a/.github/bin/verify-emscripten-profile-runtime.sh
+++ b/.github/bin/verify-emscripten-profile-runtime.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+cd "${WORK_DIR}"
+
+cat > main.c <<'EOF'
+#include <stdio.h>
+
+int main(void) {
+	puts("profile runtime smoke test");
+	return 0;
+}
+EOF
+
+assert_has_profile_runtime() {
+	local wasm="$1"
+	if ! grep -aFq 'default.profraw' "${wasm}"; then
+		echo "profile runtime is missing from instrumented output: ${wasm}" >&2
+		exit 1
+	fi
+}
+
+assert_has_no_profile_runtime() {
+	local wasm="$1"
+	if grep -aFq 'default.profraw' "${wasm}"; then
+		echo "profile runtime leaked into non-instrumented output: ${wasm}" >&2
+		exit 1
+	fi
+}
+
+emcc main.c \
+	-sMAIN_MODULE=1 \
+	-sNODERAWFS=1 \
+	-sEXIT_RUNTIME=1 \
+	-o plain-main.js
+assert_has_no_profile_runtime plain-main.wasm
+node plain-main.js >/dev/null
+if [[ -e default.profraw ]]; then
+	echo 'non-instrumented MAIN_MODULE=1 output created default.profraw' >&2
+	exit 1
+fi
+
+emcc main.c \
+	-fprofile-instr-generate \
+	-sNODERAWFS=1 \
+	-sEXIT_RUNTIME=1 \
+	-o instrumented.js
+assert_has_profile_runtime instrumented.wasm
+node instrumented.js >/dev/null
+if [[ ! -s default.profraw ]]; then
+	echo 'instrumented output did not create a non-empty default.profraw' >&2
+	exit 1
+fi
+rm default.profraw
+
+# MAIN_MODULE must also select the archive when instrumentation references it.
+# The regular instrumented binary above supplies the runtime execution check.
+emcc main.c \
+	-fprofile-instr-generate \
+	-sMAIN_MODULE=1 \
+	-sNODERAWFS=1 \
+	-sEXIT_RUNTIME=1 \
+	-o instrumented-main.js
+assert_has_profile_runtime instrumented-main.wasm
+
+cat > side.c <<'EOF'
+int dynamic_answer(void) {
+	return 42;
+}
+EOF
+
+cat > dynamic-main.c <<'EOF'
+#include <dlfcn.h>
+#include <stdio.h>
+
+typedef int (*answer_fn)(void);
+
+int main(void) {
+	void *handle = dlopen("./libanswer.so", RTLD_NOW);
+	if (!handle) {
+		fprintf(stderr, "dlopen: %s\n", dlerror());
+		return 1;
+	}
+
+	answer_fn answer = (answer_fn)dlsym(handle, "dynamic_answer");
+	if (!answer) {
+		fprintf(stderr, "dlsym: %s\n", dlerror());
+		return 2;
+	}
+
+	int result = answer();
+	dlclose(handle);
+	return result == 42 ? 0 : 3;
+}
+EOF
+
+# Match php-wasm's source -> static archive -> side module build path.
+emcc -fPIC -c side.c -o side.o
+emar rcs libanswer.a side.o
+emcc \
+	-sSIDE_MODULE=1 \
+	-Wl,--whole-archive \
+	libanswer.a \
+	-Wl,--no-whole-archive \
+	-o libanswer.so
+emcc dynamic-main.c \
+	-sMAIN_MODULE=1 \
+	-sNODERAWFS=1 \
+	-sEXIT_RUNTIME=1 \
+	-o dynamic-main.js
+assert_has_no_profile_runtime dynamic-main.wasm
+node dynamic-main.js
+if [[ -e default.profraw ]]; then
+	echo 'dynamic MAIN_MODULE=1 smoke test created default.profraw' >&2
+	exit 1
+fi
+
+echo 'Emscripten profile runtime checks passed'

--- a/.github/bin/verify-sdl-main-module.sh
+++ b/.github/bin/verify-sdl-main-module.sh
@@ -12,7 +12,7 @@ fi
 
 WASM_BASENAME="$(
 	perl -ne '
-		if (/new URL\("([^"]+\.wasm)", import\.meta\.url\)/) {
+		if (/new URL\("([^"]+\.wasm)",\s*import\.meta\.url\)/) {
 			print "$1\n";
 			exit 0;
 		}

--- a/.github/workflows/build-step.yaml
+++ b/.github/workflows/build-step.yaml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/builder-image.tar
-          key: ${{ runner.os }}-docker-${{ hashFiles('emscripten-builder.dockerfile') }}
+          key: ${{ runner.os }}-docker-${{ hashFiles('emscripten-builder.dockerfile', 'patch/emscripten-6.0.6.patch', '.github/bin/retry-embuilder.sh', '.github/bin/verify-emscripten-profile-runtime.sh') }}
 
       - name: Load builder image if cached
         if: steps.cache-docker-image.outputs.cache-hit == 'true'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/builder-image.tar
-          key: ${{ runner.os }}-docker-${{ hashFiles('emscripten-builder.dockerfile') }}
+          key: ${{ runner.os }}-docker-${{ hashFiles('emscripten-builder.dockerfile', 'patch/emscripten-6.0.6.patch', '.github/bin/retry-embuilder.sh', '.github/bin/verify-emscripten-profile-runtime.sh') }}
 
       - name: Load builder image if cached
         if: steps.cache-docker-image.outputs.cache-hit == 'true'
@@ -90,7 +90,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/builder-image.tar
-          key: ${{ runner.os }}-docker-${{ hashFiles('emscripten-builder.dockerfile') }}
+          key: ${{ runner.os }}-docker-${{ hashFiles('emscripten-builder.dockerfile', 'patch/emscripten-6.0.6.patch', '.github/bin/retry-embuilder.sh', '.github/bin/verify-emscripten-profile-runtime.sh') }}
 
       - name: Load builder image if cached
         if: steps.cache-docker-image.outputs.cache-hit == 'true'

--- a/.github/workflows/test-node-step.yaml
+++ b/.github/workflows/test-node-step.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/builder-image.tar
-          key: ${{ runner.os }}-docker-${{ hashFiles('emscripten-builder.dockerfile') }}
+          key: ${{ runner.os }}-docker-${{ hashFiles('emscripten-builder.dockerfile', 'patch/emscripten-6.0.6.patch', '.github/bin/retry-embuilder.sh', '.github/bin/verify-emscripten-profile-runtime.sh') }}
 
       - name: Load builder image if cached
         if: steps.cache-docker-image.outputs.cache-hit == 'true'

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ MAX_LOAD=$(shell echo $$(( `nproc` + $$(( `nproc` / 2 )) )))
 LTO_FLAG?=-flto
 DOCKER_ENV=PHP_DIST_DIR=$(realpath ${PHP_DIST_DIR}) ${DOCKER_COMPOSE} -p phpwasm run -T --rm -e PKG_CONFIG_PATH=${PKG_CONFIG_PATH} -e OUTER_UID=${UID}
 DOCKER_RUN=${DOCKER_ENV} emscripten-builder
-DOCKER_RUN_IN_PHP=${DOCKER_ENV} -w /src/third_party/php${PHP_VERSION}-src/ emscripten-builder
+DOCKER_RUN_IN_PHP=${DOCKER_ENV} -e EMCC_FORCE_STDLIBS=libc++abi,libc++ -w /src/third_party/php${PHP_VERSION}-src/ emscripten-builder
 MAKEFLAGS+= "-l${MAX_LOAD}"
 
 WITH_CGI=1
@@ -407,7 +407,7 @@ BUILD_FLAGS+=-f ../../php.mk \
 		-Wl,-zcommon-page-size=2097152 -Wl,-zmax-page-size=2097152 -L/src/lib/lib \
 		${SYMBOL_FLAGS} ${LTO_FLAG} -fPIC \
 		-s EXPORTED_FUNCTIONS='\''["_malloc", "_free", "_main"]'\'' \
-		-s EXPORTED_RUNTIME_METHODS='\''["ccall", "UTF8ToString", "lengthBytesUTF8", "stringToUTF8", "getValue", "setValue", "lengthBytesUTF8", "FS", "ENV"]'\'' \
+		-s EXPORTED_RUNTIME_METHODS='\''["ccall", "UTF8ToString", "lengthBytesUTF8", "stringToUTF8", "getValue", "setValue", "lengthBytesUTF8", "FS", "ENV", "HEAPU8"]'\'' \
 		-s INITIAL_MEMORY=${INITIAL_MEMORY} \
 		-s MAXIMUM_MEMORY=${MAXIMUM_MEMORY} \
 		-s ENVIRONMENT=${ENVIRONMENT}       \

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ EXTRA_MODULES=
 DYNAMIC_LIBS_GROUPED=
 STATIC_LIB_CONFIG=
 SHARED_LIB_CONFIG=
+PHP_CONFIGURE_VARS=
 
 ## More Options
 ifdef PHP_BUILDER_DIR
@@ -326,6 +327,7 @@ third_party/php${PHP_VERSION}-src/configured: ${ENV_FILE} ${ARCHIVES} ${PHP_CONF
 	${DOCKER_RUN_IN_PHP} emconfigure ./buildconf --force
 	${DOCKER_RUN_IN_PHP} emconfigure ./configure --cache-file=/src/.cache/config-cache \
 		PKG_CONFIG_PATH=${PKG_CONFIG_PATH} \
+		${PHP_CONFIGURE_VARS} \
 		EXTENSION_DIR='./'  \
 		--prefix='/src/lib/php${PHP_VERSION}' \
 		--with-config-file-path=/php.ini \

--- a/Makefile
+++ b/Makefile
@@ -666,8 +666,7 @@ ${PHP_DIST_DIR}/php${PHP_SUFFIX}-web.js: ${DEPENDENCIES} | ${ORDER_ONLY}
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/cli/php${PHP_SUFFIX}-${ENVIRONMENT}.${BUILD_TYPE}* ${PHP_DIST_DIR}
 	perl -pi -w -e 's|import\(name\)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require\("fs"\)|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_DIST_DIR}/php${PHP_SUFFIX}-${ENVIRONMENT}.${BUILD_TYPE}.* ${PHP_ASSET_DIR}
 
 ${PHP_DIST_DIR}/php${PHP_SUFFIX}-web.js.wasm.map.MAPPED: ${PHP_DIST_DIR}/php${PHP_SUFFIX}-web.js
@@ -707,8 +706,7 @@ ${PHP_DIST_DIR}/php${PHP_SUFFIX}-worker.js: ${DEPENDENCIES} | ${ORDER_ONLY}
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/cli/php${PHP_SUFFIX}-${ENVIRONMENT}.${BUILD_TYPE}* ${PHP_DIST_DIR}
 	perl -pi -w -e 's|import\(name\)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require\("fs"\)|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_DIST_DIR}/php${PHP_SUFFIX}-${ENVIRONMENT}.${BUILD_TYPE}.* ${PHP_ASSET_DIR}
 
 ${PHP_DIST_DIR}/php${PHP_SUFFIX}-worker.js.wasm.map.MAPPED: ${PHP_DIST_DIR}/php${PHP_SUFFIX}-worker.js
@@ -747,8 +745,7 @@ ${PHP_DIST_DIR}/php${PHP_SUFFIX}-node.js: ${DEPENDENCIES} | ${ORDER_ONLY}
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/cli/php${PHP_SUFFIX}-${ENVIRONMENT}.${BUILD_TYPE}* ${PHP_DIST_DIR}
 	perl -pi -w -e 's|import\(name\)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require\("fs"\)|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_DIST_DIR}/php${PHP_SUFFIX}-${ENVIRONMENT}.${BUILD_TYPE}.* ${PHP_ASSET_DIR}
 
 ${PHP_DIST_DIR}/php${PHP_SUFFIX}-node.js.wasm.map.MAPPED: ${PHP_DIST_DIR}/php${PHP_SUFFIX}-node.js
@@ -787,8 +784,7 @@ ${PHP_DIST_DIR}/php${PHP_SUFFIX}-webview.js: ${DEPENDENCIES} | ${ORDER_ONLY}
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/cli/php${PHP_SUFFIX}-${ENVIRONMENT}.${BUILD_TYPE}* ${PHP_DIST_DIR}
 	perl -pi -w -e 's|import\(name\)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require\("fs"\)|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_DIST_DIR}/php${PHP_SUFFIX}-${ENVIRONMENT}.${BUILD_TYPE}.* ${PHP_ASSET_DIR}
 
 ${PHP_DIST_DIR}/php${PHP_SUFFIX}-webview.js.wasm.map.MAPPED: ${PHP_DIST_DIR}/php${PHP_SUFFIX}-webview.js

--- a/bin/transform-logical-assignments.mjs
+++ b/bin/transform-logical-assignments.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+
+import { transformSync } from '@babel/core';
+import transformLogicalAssignmentOperators from '@babel/plugin-transform-logical-assignment-operators';
+
+const inputFile = process.argv[2];
+
+if(!inputFile)
+{
+	throw new Error('Usage: transform-logical-assignments.mjs <input-file>');
+}
+
+const input = fs.readFileSync(inputFile, 'utf8');
+const transformed = transformSync(input, {
+	babelrc: false
+	, comments: true
+	, compact: true
+	, configFile: false
+	, filename: inputFile
+	, plugins: [transformLogicalAssignmentOperators]
+	, sourceMaps: false
+	, sourceType: 'script'
+});
+
+if(!transformed?.code)
+{
+	throw new Error(`Babel did not generate output for ${inputFile}`);
+}
+
+const temporaryFile = `${inputFile}.logical-assignments.${process.pid}.tmp`;
+
+try
+{
+	fs.writeFileSync(temporaryFile, `${transformed.code}\n`);
+	fs.renameSync(temporaryFile, inputFile);
+}
+finally
+{
+	if(fs.existsSync(temporaryFile))
+	{
+		fs.unlinkSync(temporaryFile);
+	}
+}

--- a/bin/transform-logical-assignments.mjs
+++ b/bin/transform-logical-assignments.mjs
@@ -1,45 +1,64 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { transformSync } from '@babel/core';
 import transformLogicalAssignmentOperators from '@babel/plugin-transform-logical-assignment-operators';
 
-const inputFile = process.argv[2];
-
-if(!inputFile)
+/**
+ * Rewrites logical assignment operators in a generated CommonJS runtime.
+ * @param {string} inputFile Generated JavaScript file to update atomically.
+ * @returns {void} Nothing.
+ */
+export function transformLogicalAssignments(inputFile)
 {
-	throw new Error('Usage: transform-logical-assignments.mjs <input-file>');
-}
+	const input = fs.readFileSync(inputFile, 'utf8');
+	const transformed = transformSync(input, {
+		babelrc: false
+		, comments: true
+		, compact: true
+		, configFile: false
+		, filename: inputFile
+		, plugins: [transformLogicalAssignmentOperators]
+		, sourceMaps: false
+		, sourceType: 'script'
+	});
 
-const input = fs.readFileSync(inputFile, 'utf8');
-const transformed = transformSync(input, {
-	babelrc: false
-	, comments: true
-	, compact: true
-	, configFile: false
-	, filename: inputFile
-	, plugins: [transformLogicalAssignmentOperators]
-	, sourceMaps: false
-	, sourceType: 'script'
-});
-
-if(!transformed?.code)
-{
-	throw new Error(`Babel did not generate output for ${inputFile}`);
-}
-
-const temporaryFile = `${inputFile}.logical-assignments.${process.pid}.tmp`;
-
-try
-{
-	fs.writeFileSync(temporaryFile, `${transformed.code}\n`);
-	fs.renameSync(temporaryFile, inputFile);
-}
-finally
-{
-	if(fs.existsSync(temporaryFile))
+	if(!transformed?.code)
 	{
-		fs.unlinkSync(temporaryFile);
+		throw new Error(`Babel did not generate output for ${inputFile}`);
 	}
+
+	const temporaryFile = `${inputFile}.logical-assignments.${process.pid}.tmp`;
+
+	try
+	{
+		fs.writeFileSync(temporaryFile, `${transformed.code}\n`);
+		fs.renameSync(temporaryFile, inputFile);
+	}
+	finally
+	{
+		if(fs.existsSync(temporaryFile))
+		{
+			fs.unlinkSync(temporaryFile);
+		}
+	}
+}
+
+const invokedFile = process.argv[1]
+	? pathToFileURL(path.resolve(process.argv[1])).href
+	: undefined;
+
+if(invokedFile === import.meta.url)
+{
+	const inputFile = process.argv[2];
+
+	if(!inputFile)
+	{
+		throw new Error('Usage: transform-logical-assignments.mjs <input-file>');
+	}
+
+	transformLogicalAssignments(inputFile);
 }

--- a/demo-web/vite.worker.config.mjs
+++ b/demo-web/vite.worker.config.mjs
@@ -8,6 +8,7 @@ import { defineConfig } from 'vite';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const workerEntry = path.resolve(__dirname, 'src/workers/cgi-worker.mjs');
+const workerSourceRoot = path.resolve(__dirname, 'src');
 const libType = process.env.LIB_TYPE
 	|| process.env.VITE_LIB_TYPE
 	|| process.env.BUILD_TYPE
@@ -47,7 +48,7 @@ export default defineConfig({
 			, output: {
 				format: 'es'
 				, preserveModules: true
-				, preserveModulesRoot: __dirname
+				, preserveModulesRoot: workerSourceRoot
 				// Keep the service worker registration URL stable, but hash every
 				// other preserved module so browsers cannot stitch together a stale
 				// worker graph across deploys.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,6 @@ services:
       ENVIRONMENT: ${ENVIRONMENT:-web}
     volumes:
       - ${HOST_PROJECT_ROOT:-.}:/src
-      - /tmp/emsdk-cache:/emsdk/upstream/emscripten/cache/
+      - /tmp/emsdk-cache-6.0.6:/emsdk/upstream/emscripten/cache/
       - ${HOST_PROJECT_ROOT:-.}/.cache:/emsdk_portable/.data/cache/asmjs/
     command: [bash]

--- a/emscripten-builder.dockerfile
+++ b/emscripten-builder.dockerfile
@@ -56,6 +56,8 @@ RUN cd /emsdk/upstream/emscripten && {\
 	rm /tmp/emscripten.patch;\
 }
 
-RUN embuilder build USER
+COPY .github/bin/retry-embuilder.sh /usr/local/bin/retry-embuilder
+
+RUN retry-embuilder build USER
 
 RUN emcc --check

--- a/emscripten-builder.dockerfile
+++ b/emscripten-builder.dockerfile
@@ -12,17 +12,19 @@
 # FROM emscripten/emsdk:3.1.47
 # FROM emscripten/emsdk:3.1.45
 
-# ARG EMSDK_VERSION="3.1.44"
-ARG EMSDK_VERSION="3.1.67"
+# Keep this in sync with patch/emscripten-6.0.6.patch.
+ARG EMSDK_VERSION="6.0.6"
 FROM emscripten/emsdk:${EMSDK_VERSION}
 
 MAINTAINER Sean Morris <sean@seanmorr.is>
 
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 
-RUN apt-get update; \
+RUN export TMPDIR=/dev/shm; \
+	install -d /dev/shm/apt-archives/partial; \
+	apt-get update; \
 	DEBIAN_FRONTEND=noninteractive \
-	apt-get --no-install-recommends -y install \
+	apt-get -o Dir::Cache::archives=/dev/shm/apt-archives --no-install-recommends -y install \
 		build-essential \
 		automake \
 		autoconf \
@@ -45,14 +47,13 @@ RUN apt-get update; \
 		pv \
 		jq
 
-# RUN rm -rf /emsdk/upstream/emscripten
-# ADD emscripten /emsdk/upstream/emscripten
-# RUN /emsdk/upstream/emscripten/bootstrap
+COPY patch/emscripten-6.0.6.patch /tmp/emscripten.patch
 
-RUN cd /emsdk/upstream && {\
-	rm -rf emscripten;\
-	git clone https://github.com/seanmorris/emscripten.git emscripten --depth=1 --branch sm-updates;\
-	emscripten/bootstrap; \
+RUN cd /emsdk/upstream/emscripten && {\
+	git apply --check /tmp/emscripten.patch;\
+	git apply /tmp/emscripten.patch;\
+	python3 -m compileall -q emcc.py tools;\
+	rm /tmp/emscripten.patch;\
 }
 
 RUN embuilder build USER

--- a/emscripten-builder.dockerfile
+++ b/emscripten-builder.dockerfile
@@ -57,7 +57,10 @@ RUN cd /emsdk/upstream/emscripten && {\
 }
 
 COPY .github/bin/retry-embuilder.sh /usr/local/bin/retry-embuilder
+COPY .github/bin/verify-emscripten-profile-runtime.sh /usr/local/bin/verify-emscripten-profile-runtime
 
 RUN retry-embuilder build USER
+
+RUN bash /usr/local/bin/verify-emscripten-profile-runtime
 
 RUN emcc --check

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "php-wasm-builder": "bin/php-wasm-builder.js"
       },
       "devDependencies": {
+        "@babel/plugin-transform-logical-assignment-operators": "^7.25.8",
         "@playwright/test": "^1.55.0",
         "@types/node": "^24.8.0",
         "eslint": "^10.2.1",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "vrzno"
   ],
   "devDependencies": {
+    "@babel/plugin-transform-logical-assignment-operators": "^7.25.8",
     "@types/node": "^24.8.0",
     "@playwright/test": "^1.55.0",
     "eslint": "^10.2.1",

--- a/packages/gd/static.mak
+++ b/packages/gd/static.mak
@@ -223,7 +223,7 @@ third_party/jpeg-9f/README:
 
 lib/lib/libjpeg.a: third_party/jpeg-9f/README
 	@ echo -e "\e[33;4mBuilding LIBJPEG\e[0m"
-	${DOCKER_RUN_IN_LIBJPEG} emconfigure ./configure --prefix=/src/lib/ --cache-file=/tmp/config-cache
+	${DOCKER_RUN_IN_LIBJPEG} emconfigure ./configure --prefix=/src/lib/ --cache-file=/tmp/config-cache --disable-shared --enable-static
 	${DOCKER_RUN_IN_LIBJPEG} emmake make -j${CPU_COUNT}
 	${DOCKER_RUN_IN_LIBJPEG} emmake make install
 

--- a/packages/gd/static.mak
+++ b/packages/gd/static.mak
@@ -250,7 +250,8 @@ lib/lib/libpng.a: third_party/libpng/.gitignore lib/lib/libz.a
 		-DCMAKE_C_FLAGS="-fPIC -flto -O${SUB_OPTIMIZE} " \
 		-DZLIB_LIBRARY="/src/lib/lib/libz.a" \
 		-DZLIB_INCLUDE_DIR="/src/lib/include/" \
-		-DPNG_SHARED="ON"
+		-DPNG_SHARED="OFF" \
+		-DPNG_STATIC="ON"
 	${DOCKER_RUN_IN_LIBPNG} emmake make -j1;
 	${DOCKER_RUN_IN_LIBPNG} emmake make install;
 
@@ -284,10 +285,9 @@ lib/lib/libwebp.so: lib/lib/libwebp.a lib/lib/libsharpyuv.a
 
 lib/lib/libwebp.a: third_party/libwebp-${LIBWEBP_TAG}/README.md
 	@ echo -e "\e[33;4mBuilding LIBWEBP\e[0m"
-	${DOCKER_RUN_IN_LIBWEBP} emconfigure ./configure --prefix=/src/lib/ --cache-file=/tmp/config-cache CFLAGS='-fPIC -flto -O${SUB_OPTIMIZE}'
+	${DOCKER_RUN_IN_LIBWEBP} emconfigure ./configure --prefix=/src/lib/ --cache-file=/tmp/config-cache --disable-shared --enable-static CFLAGS='-fPIC -flto -O${SUB_OPTIMIZE}'
 	${DOCKER_RUN_IN_LIBWEBP} emmake make -f /src/packages/gd/webp.mak -j${CPU_COUNT}
 	${DOCKER_RUN_IN_LIBWEBP} emmake make -f /src/packages/gd/webp.mak install
-	${DOCKER_RUN} rm /src/lib/lib/libwebp.so
 
 packages/gd/libwebp.so: lib/lib/libwebp.so
 	cp -rL $^ $@

--- a/packages/gd/static.mak
+++ b/packages/gd/static.mak
@@ -183,7 +183,7 @@ packages/gd/php${PHP_VERSION}-gd.so: ${PHPIZE} third_party/php${PHP_VERSION}-gd/
 	@ echo -e "\e[33;4mBuilding php-gd\e[0m"
 	${DOCKER_RUN_IN_EXT_GD} chmod +x /src/third_party/php${PHP_VERSION}-src/scripts/phpize;
 	${DOCKER_RUN_IN_EXT_GD} /src/third_party/php${PHP_VERSION}-src/scripts/phpize;
-	${DOCKER_RUN_IN_EXT_GD} emconfigure ./configure PKG_CONFIG_PATH=${PKG_CONFIG_PATH} --prefix='/src/lib/php${PHP_VERSION}' --with-php-config='/src/lib/php${PHP_VERSION}/bin/php-config' ${GD_FLAGS} --cache-file=/tmp/config-cache;
+	${DOCKER_RUN_IN_EXT_GD} emconfigure ./configure PKG_CONFIG_PATH=${PKG_CONFIG_PATH} WEBP_LIBS='-L/src/lib/lib -lwebp -lsharpyuv' --prefix='/src/lib/php${PHP_VERSION}' --with-php-config='/src/lib/php${PHP_VERSION}/bin/php-config' ${GD_FLAGS} --cache-file=/tmp/config-cache;
 	${DOCKER_RUN_IN_EXT_GD} sed -i 's#-shared#-static#g' Makefile;
 	${DOCKER_RUN_IN_EXT_GD} sed -i 's#-export-dynamic##g' Makefile;
 	${DOCKER_RUN_IN_EXT_GD} emmake make -j${CPU_COUNT} EXTRA_INCLUDES='-I/src/third_party/php${PHP_VERSION}-src';
@@ -277,12 +277,14 @@ third_party/libwebp-${LIBWEBP_TAG}/README.md:
 	${DOCKER_RUN} tar -xvzf libwebp-${LIBWEBP_TAG}.tar.gz -C third_party
 	${DOCKER_RUN} rm libwebp-${LIBWEBP_TAG}.tar.gz
 
-lib/lib/libwebp.so: lib/lib/libwebp.a
-	${DOCKER_RUN} emcc -shared -o /src/$@ -fPIC -flto -sSIDE_MODULE=1 -O${SUB_OPTIMIZE} -Wl,--whole-archive /src/$^
+lib/lib/libsharpyuv.a: lib/lib/libwebp.a
+
+lib/lib/libwebp.so: lib/lib/libwebp.a lib/lib/libsharpyuv.a
+	${DOCKER_RUN} emcc -shared -o /src/$@ -fPIC -flto -sSIDE_MODULE=1 -O${SUB_OPTIMIZE} -Wl,--whole-archive $(addprefix /src/,$^)
 
 lib/lib/libwebp.a: third_party/libwebp-${LIBWEBP_TAG}/README.md
 	@ echo -e "\e[33;4mBuilding LIBWEBP\e[0m"
-	${DOCKER_RUN_IN_LIBWEBP} emconfigure ./configure --prefix=/src/lib/ --cache-file=/tmp/config-cache
+	${DOCKER_RUN_IN_LIBWEBP} emconfigure ./configure --prefix=/src/lib/ --cache-file=/tmp/config-cache CFLAGS='-fPIC -flto -O${SUB_OPTIMIZE}'
 	${DOCKER_RUN_IN_LIBWEBP} emmake make -f /src/packages/gd/webp.mak -j${CPU_COUNT}
 	${DOCKER_RUN_IN_LIBWEBP} emmake make -f /src/packages/gd/webp.mak install
 	${DOCKER_RUN} rm /src/lib/lib/libwebp.so

--- a/packages/iconv/static.mak
+++ b/packages/iconv/static.mak
@@ -16,6 +16,16 @@ ifeq (${WITH_ICONV},1)
 WITH_ICONV=dynamic
 endif
 
+ifneq (${WITH_ICONV},0)
+ICONV_CONFIGURE_VARS=ac_cv_lib_iconv_libiconv=yes php_cv_iconv_errno=yes php_cv_iconv_ignore=no
+
+ifneq ($(filter ${PHP_VERSION},8.0 8.1 8.2 8.3),)
+ICONV_CONFIGURE_VARS+=php_cv_iconv_implementation=gnu_libiconv
+endif
+
+PHP_CONFIGURE_VARS+=${ICONV_CONFIGURE_VARS}
+endif
+
 ifeq (${WITH_ICONV},static)
 CONFIGURE_FLAGS+= --with-iconv=/src/lib
 ARCHIVES+= lib/lib/libiconv.a
@@ -77,7 +87,7 @@ packages/iconv/php${PHP_VERSION}-iconv.so: ${PHPIZE} packages/iconv/libiconv.so 
 	# Cache the known libiconv symbol and PHP's own cross-compilation defaults.
 	# This avoids a no-prototype link probe (invalid for strict Wasm signatures)
 	# and runtime probes whose SIDE_MODULE is outside the probe's working dir.
-	${DOCKER_RUN_IN_EXT_ICONV} emconfigure ./configure PKG_CONFIG_PATH=${PKG_CONFIG_PATH} ac_cv_lib_iconv_libiconv=yes php_cv_iconv_errno=yes php_cv_iconv_ignore=no --with-iconv=/src/lib --prefix='/src/lib/php${PHP_VERSION}' --with-php-config=/src/lib/php${PHP_VERSION}/bin/php-config --cache-file=/tmp/config-cache;
+	${DOCKER_RUN_IN_EXT_ICONV} emconfigure ./configure PKG_CONFIG_PATH=${PKG_CONFIG_PATH} ${ICONV_CONFIGURE_VARS} --with-iconv=/src/lib --prefix='/src/lib/php${PHP_VERSION}' --with-php-config=/src/lib/php${PHP_VERSION}/bin/php-config --cache-file=/tmp/config-cache;
 	${DOCKER_RUN_IN_EXT_ICONV} sed -i 's#-shared#-static#g' Makefile;
 	${DOCKER_RUN_IN_EXT_ICONV} sed -i 's#-export-dynamic#-all-static#g' Makefile;
 	${DOCKER_RUN_IN_EXT_ICONV} emmake make -j${CPU_COUNT} EXTRA_INCLUDES='-I/src/third_party/php${PHP_VERSION}-src';

--- a/packages/iconv/static.mak
+++ b/packages/iconv/static.mak
@@ -74,7 +74,10 @@ packages/iconv/php${PHP_VERSION}-iconv.so: ${PHPIZE} packages/iconv/libiconv.so 
 	@ echo -e "\e[33;4mBuilding php-iconv\e[0m"
 	${DOCKER_RUN_IN_EXT_ICONV} chmod +x /src/third_party/php${PHP_VERSION}-src/scripts/phpize;
 	${DOCKER_RUN_IN_EXT_ICONV} /src/third_party/php${PHP_VERSION}-src/scripts/phpize;
-	${DOCKER_RUN_IN_EXT_ICONV} emconfigure ./configure PKG_CONFIG_PATH=${PKG_CONFIG_PATH} --with-iconv=/src/lib --prefix='/src/lib/php${PHP_VERSION}' --with-php-config=/src/lib/php${PHP_VERSION}/bin/php-config --cache-file=/tmp/config-cache;
+	# Cache the known libiconv symbol and PHP's own cross-compilation defaults.
+	# This avoids a no-prototype link probe (invalid for strict Wasm signatures)
+	# and runtime probes whose SIDE_MODULE is outside the probe's working dir.
+	${DOCKER_RUN_IN_EXT_ICONV} emconfigure ./configure PKG_CONFIG_PATH=${PKG_CONFIG_PATH} ac_cv_lib_iconv_libiconv=yes php_cv_iconv_errno=yes php_cv_iconv_ignore=no --with-iconv=/src/lib --prefix='/src/lib/php${PHP_VERSION}' --with-php-config=/src/lib/php${PHP_VERSION}/bin/php-config --cache-file=/tmp/config-cache;
 	${DOCKER_RUN_IN_EXT_ICONV} sed -i 's#-shared#-static#g' Makefile;
 	${DOCKER_RUN_IN_EXT_ICONV} sed -i 's#-export-dynamic#-all-static#g' Makefile;
 	${DOCKER_RUN_IN_EXT_ICONV} emmake make -j${CPU_COUNT} EXTRA_INCLUDES='-I/src/third_party/php${PHP_VERSION}-src';

--- a/packages/libxml/static.mak
+++ b/packages/libxml/static.mak
@@ -54,7 +54,7 @@ third_party/libxml2/.gitignore:
 lib/lib/libxml2.a: third_party/libxml2/.gitignore
 	@ echo -e "\e[33;4mBuilding LibXML2\e[0m"
 	${DOCKER_RUN_IN_LIBXML} ./autogen.sh
-	${DOCKER_RUN_IN_LIBXML} emconfigure ./configure --with-http=no --with-ftp=no --with-python=no --with-threads=no --prefix=/src/lib/ --cache-file=/tmp/config-cache
+	${DOCKER_RUN_IN_LIBXML} emconfigure ./configure --with-http=no --with-ftp=no --with-python=no --with-threads=no --disable-shared --enable-static --prefix=/src/lib/ --cache-file=/tmp/config-cache
 	${DOCKER_RUN_IN_LIBXML} emmake make -j${CPU_COUNT}
 	${DOCKER_RUN_IN_LIBXML} emmake make install
 

--- a/packages/libyaml/static.mak
+++ b/packages/libyaml/static.mak
@@ -63,7 +63,7 @@ PHP_YAML_VERSION=2.3.0
 
 third_party/php${PHP_VERSION}-yaml/config.m4:
 	@ echo -e "\e[33;4mDownloading ext-yaml\e[0m"
-	${DOCKER_RUN} wget --tries=5 --waitretry=2 --timeout=20 -q https://pecl.php.net/get/yaml-${PHP_YAML_VERSION}.tgz
+	${DOCKER_RUN} /src/.github/bin/retry-download.sh https://pecl.php.net/get/yaml-${PHP_YAML_VERSION}.tgz yaml-${PHP_YAML_VERSION}.tgz
 	${DOCKER_RUN} tar -C third_party -xvzf yaml-${PHP_YAML_VERSION}.tgz yaml-${PHP_YAML_VERSION}
 	${DOCKER_RUN} mv third_party/yaml-${PHP_YAML_VERSION} third_party/php${PHP_VERSION}-yaml
 	${DOCKER_RUN} rm yaml-${PHP_YAML_VERSION}.tgz

--- a/packages/libzip/static.mak
+++ b/packages/libzip/static.mak
@@ -51,6 +51,7 @@ lib/lib/libzip.a: third_party/libzip/.gitignore lib/lib/libz.a
 	@ echo -e "\e[33;4mBuilding LibZip\e[0m"
 	${DOCKER_RUN_IN_LIBZIP} emcmake cmake . \
 		-DCMAKE_INSTALL_PREFIX=/src/lib/ \
+		-DBUILD_SHARED_LIBS=OFF \
 		-DZLIB_LIBRARY=/src/lib/lib/libz.a \
 		-DZLIB_INCLUDE_DIR=/src/lib/include/ \
 		-DCMAKE_BUILD_TYPE=Release \

--- a/packages/mbstring/static.mak
+++ b/packages/mbstring/static.mak
@@ -73,7 +73,7 @@ third_party/oniguruma/.gitignore:
 lib/lib/libonig.a: third_party/oniguruma/.gitignore
 	@ echo -e "\e[33;4mBuilding ONIGURUMA\e[0m"
 	${DOCKER_RUN_IN_ONIGURUMA} emconfigure ./autogen.sh
-	${DOCKER_RUN_IN_ONIGURUMA} emconfigure ./configure --prefix=/src/lib/ --enable-shared=yes --enable-static=yes --cache-file=/tmp/config-cache
+	${DOCKER_RUN_IN_ONIGURUMA} emconfigure ./configure --prefix=/src/lib/ --disable-shared --enable-static --cache-file=/tmp/config-cache
 	${DOCKER_RUN_IN_ONIGURUMA} emmake make -j${CPU_COUNT}
 	${DOCKER_RUN_IN_ONIGURUMA} emmake make install
 

--- a/packages/php-cgi-wasm/static.mak
+++ b/packages/php-cgi-wasm/static.mak
@@ -162,8 +162,7 @@ ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-web.js: ${CGI_DEPENDENCIES} | ${ORDER_O
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/cgi/php${PHP_SUFFIX}-cgi-${ENVIRONMENT}.${BUILD_TYPE}* ${PHP_CGI_DIST_DIR}/
 	perl -pi -w -e 's|import(name)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require("fs")|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-${ENVIRONMENT}.${BUILD_TYPE}.* ${PHP_CGI_ASSET_DIR}
 
 ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-web.js.wasm.map.MAPPED: ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-web.js
@@ -200,8 +199,7 @@ ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-worker.js: ${CGI_DEPENDENCIES} | ${ORDE
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/cgi/php${PHP_SUFFIX}-cgi-${ENVIRONMENT}.${BUILD_TYPE}* ${PHP_CGI_DIST_DIR}/
 	perl -pi -w -e 's|import(name)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require("fs")|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-${ENVIRONMENT}.${BUILD_TYPE}.* ${PHP_CGI_ASSET_DIR}
 
 ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-worker.js.wasm.map.MAPPED: ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-worker.js
@@ -238,8 +236,7 @@ ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-node.js: ${CGI_DEPENDENCIES} | ${ORDER_
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/cgi/php${PHP_SUFFIX}-cgi-${ENVIRONMENT}.${BUILD_TYPE}* ${PHP_CGI_DIST_DIR}/
 	perl -pi -w -e 's|import(name)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require("fs")|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-${ENVIRONMENT}.${BUILD_TYPE}.* ${PHP_CGI_ASSET_DIR}
 
 ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-node.js.wasm.map.MAPPED: ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-node.js
@@ -275,8 +272,7 @@ ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-webview.js: ${CGI_DEPENDENCIES} | ${ORD
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/cgi/php${PHP_SUFFIX}-cgi-${ENVIRONMENT}.${BUILD_TYPE}* ${PHP_CGI_DIST_DIR}/
 	perl -pi -w -e 's|import(name)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require("fs")|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-${ENVIRONMENT}.${BUILD_TYPE}.* ${PHP_CGI_ASSET_DIR}
 
 ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-webview.js.wasm.map.MAPPED: ${PHP_CGI_DIST_DIR}/php${PHP_SUFFIX}-cgi-webview.js

--- a/packages/php-cli-wasm/static.mak
+++ b/packages/php-cli-wasm/static.mak
@@ -154,8 +154,7 @@ ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-web.js: ${CLI_DEPENDENCIES} | ${ORDER_O
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/cli/php${PHP_SUFFIX}-cli-${ENVIRONMENT}${RELEASE_SUFFIX}.${BUILD_TYPE}* ${PHP_CLI_DIST_DIR}/
 	perl -pi -w -e 's|import(name)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require("fs")|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-${ENVIRONMENT}${RELEASE_SUFFIX}.${BUILD_TYPE}.* ${PHP_CLI_ASSET_DIR}
 
 ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-web.js.wasm.map.MAPPED: ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-web.js
@@ -196,8 +195,7 @@ ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-worker.js: ${CLI_DEPENDENCIES} | ${ORDE
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/cli/php${PHP_SUFFIX}-cli-${ENVIRONMENT}${RELEASE_SUFFIX}.${BUILD_TYPE}* ${PHP_CLI_DIST_DIR}/
 	perl -pi -w -e 's|import(name)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require("fs")|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-${ENVIRONMENT}${RELEASE_SUFFIX}.${BUILD_TYPE}.* ${PHP_CLI_ASSET_DIR}
 
 ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-worker.js.wasm.map.MAPPED: ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-worker.js
@@ -238,8 +236,7 @@ ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-node.js: ${CLI_DEPENDENCIES} | ${ORDER_
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/cli/php${PHP_SUFFIX}-cli-${ENVIRONMENT}${RELEASE_SUFFIX}.${BUILD_TYPE}* ${PHP_CLI_DIST_DIR}/
 	perl -pi -w -e 's|import(name)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require("fs")|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-${ENVIRONMENT}${RELEASE_SUFFIX}.${BUILD_TYPE}.* ${PHP_CLI_ASSET_DIR}
 
 ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-node.js.wasm.map.MAPPED: ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-node.js
@@ -279,8 +276,7 @@ ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-webview.js: ${CLI_DEPENDENCIES} | ${ORD
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/cli/php${PHP_SUFFIX}-cli-${ENVIRONMENT}${RELEASE_SUFFIX}.${BUILD_TYPE}* ${PHP_CLI_DIST_DIR}/
 	perl -pi -w -e 's|import(name)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require("fs")|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-${ENVIRONMENT}${RELEASE_SUFFIX}.${BUILD_TYPE}.* ${PHP_CLI_ASSET_DIR}
 
 ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-webview.js.wasm.map.MAPPED: ${PHP_CLI_DIST_DIR}/php${PHP_SUFFIX}-cli-webview.js

--- a/packages/php-dbg-wasm/static.mak
+++ b/packages/php-dbg-wasm/static.mak
@@ -152,8 +152,7 @@ ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-web.js: ${DBG_DEPENDENCIES} | ${ORDER_O
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/phpdbg/php${PHP_SUFFIX}-dbg-${ENVIRONMENT}.${BUILD_TYPE}* ${PHP_DBG_DIST_DIR}/
 	perl -pi -w -e 's|import(name)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require("fs")|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-${ENVIRONMENT}.${BUILD_TYPE}.* ${PHP_DBG_ASSET_DIR}
 
 ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-web.js.wasm.map.MAPPED: ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-web.js
@@ -190,8 +189,7 @@ ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-worker.js: ${DBG_DEPENDENCIES} | ${ORDE
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/phpdbg/php${PHP_SUFFIX}-dbg-${ENVIRONMENT}.${BUILD_TYPE}* ${PHP_DBG_DIST_DIR}/
 	perl -pi -w -e 's|import(name)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require("fs")|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-${ENVIRONMENT}.${BUILD_TYPE}.* ${PHP_DBG_ASSET_DIR}
 
 ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-worker.js.wasm.map.MAPPED: ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-worker.js
@@ -228,8 +226,7 @@ ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-node.js: ${DBG_DEPENDENCIES} | ${ORDER_
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/phpdbg/php${PHP_SUFFIX}-dbg-${ENVIRONMENT}.${BUILD_TYPE}* ${PHP_DBG_DIST_DIR}/
 	perl -pi -w -e 's|import(name)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require("fs")|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-${ENVIRONMENT}.${BUILD_TYPE}.* ${PHP_DBG_ASSET_DIR}
 
 ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-node.js.wasm.map.MAPPED: ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-node.js
@@ -265,8 +262,7 @@ ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-webview.js: ${DBG_DEPENDENCIES} | ${ORD
 	cp -Lprf third_party/php${PHP_VERSION}-src/sapi/phpdbg/php${PHP_SUFFIX}-dbg-${ENVIRONMENT}.${BUILD_TYPE}* ${PHP_DBG_DIST_DIR}/
 	perl -pi -w -e 's|import(name)|import(/* webpackIgnore: true */ name)|g' $@
 	perl -pi -w -e 's|require("fs")|require(/* webpackIgnore: true */ "fs")|g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\?\?=#\1=\1??#g' $@
-	perl -pi -w -e 's#([^;{}]+)\s*\|\|=#\1=\1\|\|#g' $@
+	node bin/transform-logical-assignments.mjs $@
 	- cp -Lprf ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-${ENVIRONMENT}.${BUILD_TYPE}.* ${PHP_DBG_ASSET_DIR}
 
 ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-webview.js.wasm.map.MAPPED: ${PHP_DBG_DIST_DIR}/php${PHP_SUFFIX}-dbg-webview.js

--- a/packages/sdl/static.mak
+++ b/packages/sdl/static.mak
@@ -4,7 +4,7 @@ DOCKER_RUN_IN_EXT_SDL=${DOCKER_ENV} -e EMCC_CFLAGS='-fPIC -flto -O${SUB_OPTIMIZE
 
 third_party/php${PHP_VERSION}-sdl/config.m4:
 	@ echo -e "\e[33;4mDownloading ext-sdl\e[0m"
-	${DOCKER_RUN} wget --tries=5 --waitretry=2 --timeout=20 -q https://pecl.php.net/get/sdl-2.7.0.tgz
+	${DOCKER_RUN} /src/.github/bin/retry-download.sh https://pecl.php.net/get/sdl-2.7.0.tgz sdl-2.7.0.tgz
 	${DOCKER_RUN} tar -C third_party -xvzf sdl-2.7.0.tgz sdl-2.7.0
 	${DOCKER_RUN} mv third_party/sdl-2.7.0 third_party/php${PHP_VERSION}-sdl
 	${DOCKER_RUN} rm sdl-2.7.0.tgz

--- a/packages/sdl/static.mak
+++ b/packages/sdl/static.mak
@@ -28,12 +28,12 @@ lib/bin/sdl2-config: packages/sdl/sdl2-config.in lib/lib/libSDL2.a lib/lib/libGL
 
 lib/lib/libGL.a:
 	@ echo -e "\e[33;4mBuilding LIBGL\e[0m"
-	${DOCKER_RUN} embuilder build libGL-mt-webgl2-ofb-full_es3-getprocaddr --lto --pic --verbose
+	${DOCKER_RUN} retry-embuilder build libGL-mt-webgl2-ofb-full_es3-getprocaddr --lto --pic --verbose
 	${DOCKER_RUN} cp /emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten/lto-pic/libGL-mt-webgl2-ofb-full_es3-getprocaddr.a /src/$@
 
 lib/lib/libSDL2.a:
 	@ echo -e "\e[33;4mBuilding LIBSDL\e[0m"
-	${DOCKER_RUN} embuilder build sdl2 --lto --pic --verbose
+	${DOCKER_RUN} retry-embuilder build sdl2 --lto --pic --verbose
 	${DOCKER_RUN} mkdir -p /src/lib/include /src/lib/lib
 	${DOCKER_RUN} rm -rf /src/lib/include/SDL2
 	${DOCKER_RUN} cp -r /emsdk/upstream/emscripten/cache/sysroot/include/SDL2 /src/lib/include/SDL2

--- a/packages/tidy/static.mak
+++ b/packages/tidy/static.mak
@@ -72,6 +72,8 @@ lib/lib/libtidy.a: third_party/tidy-html5/.gitignore
 	${DOCKER_RUN_IN_TIDY} emcmake cmake . \
 		-DCMAKE_INSTALL_PREFIX=/src/lib/ \
 		-DCMAKE_BUILD_TYPE=Release \
+		-DBUILD_SHARED_LIB=OFF \
+		-DTIDY_CONSOLE_SHARED=OFF \
 		-DCMAKE_C_FLAGS="-I/emsdk/upstream/emscripten/system/lib/libc/musl/include/ -fPIC "
 	${DOCKER_RUN_IN_TIDY} emmake make -j`nproc`;
 	${DOCKER_RUN_IN_TIDY} emmake make install;

--- a/packages/tidy/static.mak
+++ b/packages/tidy/static.mak
@@ -75,6 +75,9 @@ lib/lib/libtidy.a: third_party/tidy-html5/.gitignore
 		-DCMAKE_C_FLAGS="-I/emsdk/upstream/emscripten/system/lib/libc/musl/include/ -fPIC "
 	${DOCKER_RUN_IN_TIDY} emmake make -j`nproc`;
 	${DOCKER_RUN_IN_TIDY} emmake make install;
+	# Tidy 5.6 names its static archive libtidys.a to distinguish it from
+	# the shared library. Keep the conventional name expected by PHP's -ltidy.
+	${DOCKER_RUN_IN_TIDY} cp /src/lib/lib/libtidys.a /src/lib/lib/libtidy.a
 
 lib/lib/libtidy.so: lib/lib/libtidy.a
 	${DOCKER_RUN_IN_TIDY} emcc -shared -o /src/$@ -fPIC -flto -sSIDE_MODULE=1 -O${SUB_OPTIMIZE} -Wl,--whole-archive /src/$^

--- a/patch/emscripten-6.0.6.patch
+++ b/patch/emscripten-6.0.6.patch
@@ -1,0 +1,180 @@
+diff --git a/emcc.py b/emcc.py
+index aae61e4..f39c6ec 100644
+--- a/emcc.py
++++ b/emcc.py
+@@ -82,7 +82,7 @@ LINK_ONLY_FLAGS = {
+     '--emit-symbol-map', '--emrun', '--exclude-file', '--extern-post-js',
+     '--extern-pre-js', '--ignore-dynamic-linking', '--js-library',
+     '--js-transform', '--oformat', '--output_eol', '--output-eol',
+-    '--post-js', '--pre-js', '--preload-file', '--profiling-funcs',
++    '--post-js', '--pre-js', '--preload-file', '--preload-name', '--profiling-funcs',
+     '--proxy-to-worker', '--shell-file', '--source-map-base',
+     '--threadprofiler', '--use-preload-plugins',
+ }
+diff --git a/src/lib/libidbfs.js b/src/lib/libidbfs.js
+index ac51fe7..0b9c8df 100644
+--- a/src/lib/libidbfs.js
++++ b/src/lib/libidbfs.js
+@@ -265,7 +265,9 @@ addToLibrary({
+       }
+     },
+     storeLocalEntry: (path, entry, callback) => {
++      var previousIgnore = FS.ignorePermissions;
+       try {
++        FS.ignorePermissions = true;
+         if (FS.isDir(entry['mode'])) {
+           FS.mkdirTree(path, entry['mode']);
+         } else if (FS.isLink(entry['mode'])) {
+@@ -280,6 +282,8 @@ addToLibrary({
+         FS.utime(path, entry['timestamp'], entry['timestamp']);
+       } catch (e) {
+         return callback(e);
++      } finally {
++        FS.ignorePermissions = previousIgnore;
+       }
+
+       callback(null);
+diff --git a/src/lib/libdylink.js b/src/lib/libdylink.js
+--- a/src/lib/libdylink.js
++++ b/src/lib/libdylink.js
+@@ -1303,7 +1303,7 @@ addToLibrary({
+   _dlopen_js__async: 'auto',
+   _dlopen_js: (handle) =>
+ #if ASYNCIFY
+-    dlopenInternal(handle, { loadAsync: true }),
++    dlopenInternal(handle, { loadAsync: true }).catch(() => 0),
+ #else
+     dlopenInternal(handle, { loadAsync: false }),
+ #endif
+diff --git a/src/preamble.js b/src/preamble.js
+index 7585eae..32d7fd5 100644
+--- a/src/preamble.js
++++ b/src/preamble.js
+@@ -449,7 +449,10 @@ function findWasmBinary() {
+ #endif
+
+   if (Module['locateFile']) {
+-    return locateFile('{{{ WASM_BINARY_FILE }}}');
++    return locateFile(
++      '{{{ WASM_BINARY_FILE }}}',
++      new URL('{{{ WASM_BINARY_FILE }}}', import.meta.url).href,
++    );
+   }
+
+   // Use bundler-friendly `new URL(..., import.meta.url)` pattern; works in browsers too.
+diff --git a/src/shell.js b/src/shell.js
+index ad4fd53..643d203 100644
+--- a/src/shell.js
++++ b/src/shell.js
+@@ -173,16 +173,16 @@ if (ENVIRONMENT_IS_WORKER) {
+
+ // `/` should be present at the end if `scriptDirectory` is not empty
+ var scriptDirectory = '';
+-function locateFile(path) {
++function locateFile(path, defaultPath = null) {
+ #if RUNTIME_DEBUG
+   dbg('locateFile:', path, 'scriptDirectory:', scriptDirectory);
+ #endif
+ #if expectToReceiveOnModule('locateFile')
+   if (Module['locateFile']) {
+-    return Module['locateFile'](path, scriptDirectory);
++    return Module['locateFile'](path, scriptDirectory) ?? defaultPath ?? scriptDirectory + path;
+   }
+ #endif
+-  return scriptDirectory + path;
++  return defaultPath ?? scriptDirectory + path;
+ }
+
+ // Hooks that are implemented differently in different runtime environments.
+diff --git a/tools/cmdline.py b/tools/cmdline.py
+index 1b6d02b..9ddf02e 100644
+--- a/tools/cmdline.py
++++ b/tools/cmdline.py
+@@ -95,6 +95,7 @@ class EmccOptions:
+   post_link = False
+   pre_js: list[str] = [] # before all js
+   preload_files: list[str] = []
++  preload_name: str | None = None
+   relocatable = False
+   reproduce = os.getenv('EMCC_REPRODUCE')  # None by default.
+   requested_debug = None
+@@ -433,6 +434,8 @@ def parse_args(newargs):  # ruff: ignore[complex-structure, too-many-branches, t
+       options.embed_files.append(consume_arg())
+     elif check_arg('--preload-file'):
+       options.preload_files.append(consume_arg())
++    elif check_arg('--preload-name'):
++      options.preload_name = consume_arg()
+     elif check_arg('--exclude-file'):
+       options.exclude_files.append(consume_arg())
+     elif check_flag('--use-preload-cache'):
+diff --git a/tools/emscripten.py b/tools/emscripten.py
+index 38dfd6c..c90eb2e 100644
+--- a/tools/emscripten.py
++++ b/tools/emscripten.py
+@@ -1012,7 +1012,10 @@ def create_receiving(function_exports, other_exports, library_symbols, aliases):
+   for export, info in other_exports:
+     exports[export.name] = (export, info)
+
+-  mangled = [asmjs_mangle(s) for s in exports] + list(aliases.keys())
++  # Some Wasm exports alias to the same JavaScript symbol.  In particular,
++  # `main` and `__main_argc_argv` both mangle to `_main`.  Declare each JS
++  # binding only once so Closure does not reject the duplicate declaration.
++  mangled = list(dict.fromkeys([asmjs_mangle(s) for s in exports] + list(aliases.keys())))
+   if settings.ASSERTIONS:
+     # In debug builds we generate trapping functions in case
+     # folks try to call/use a reference that was taken before the
+@@ -1054,9 +1057,13 @@ def create_receiving(function_exports, other_exports, library_symbols, aliases):
+         # are created by binaryen will be missing.
+         continue
+       receiving.append(f"  assert(typeof wasmExports['{sym}'] != 'undefined', 'missing Wasm export: {sym}');")
++  seen_mangled = set()
+   for sym, info in exports.items():
+     is_function = type(info) == webassembly.FuncType
+     mangled = asmjs_mangle(sym)
++    if mangled in seen_mangled:
++      continue
++    seen_mangled.add(mangled)
+     assignment = mangled
+     if generate_dyncall_assignment and is_function and sym.startswith('dynCall_'):
+       sig_str = sym.removeprefix('dynCall_')
+diff --git a/tools/file_packager.py b/tools/file_packager.py
+index 5db149e..f03b8db 100755
+--- a/tools/file_packager.py
++++ b/tools/file_packager.py
+@@ -762,7 +762,9 @@ def generate_preload_js(data_target, data_files, metadata, js_file):
+       }
+       var PACKAGE_NAME = '%s';
+       var REMOTE_PACKAGE_BASE = '%s';
+-      var REMOTE_PACKAGE_NAME = Module['locateFile'] ? Module['locateFile'](REMOTE_PACKAGE_BASE, '') : REMOTE_PACKAGE_BASE;\n''' % (js_manipulation.escape_for_js_string(data_target), js_manipulation.escape_for_js_string(remote_package_name))
++      var REMOTE_PACKAGE_NAME = Module['locateFile']
++        ? (Module['locateFile'](REMOTE_PACKAGE_BASE, '') ?? REMOTE_PACKAGE_BASE)
++        : REMOTE_PACKAGE_BASE;\n''' % (js_manipulation.escape_for_js_string(data_target), js_manipulation.escape_for_js_string(remote_package_name))
+     metadata['remote_package_size'] = remote_package_size
+     ret += "      var REMOTE_PACKAGE_SIZE = metadata['remote_package_size'];\n"
+
+diff --git a/tools/link.py b/tools/link.py
+index 8d78776..a82bb98 100644
+--- a/tools/link.py
++++ b/tools/link.py
+@@ -3070,9 +3070,12 @@ def package_files(target):
+   rtn = []
+   logger.debug('setting up files')
+   file_args = ['--from-emcc']
++  data_target = utils.replace_suffix(target, '.data')
+   if options.preload_files:
+     file_args.append('--preload')
+     file_args += options.preload_files
++    if options.preload_name:
++      data_target = os.path.join(os.path.dirname(target), options.preload_name + '.data')
+   if options.embed_files:
+     file_args.append('--embed')
+     file_args += options.embed_files
+@@ -3095,7 +3098,7 @@ def package_files(target):
+     rtn.append(object_file)
+
+   cmd = building.get_command_with_possible_response_file(
+-    [shared.FILE_PACKAGER, utils.replace_suffix(target, '.data'), *file_args])
++    [shared.FILE_PACKAGER, data_target, *file_args])
+   if options.preload_files:
+     # Preloading files uses --pre-js code that runs before the module is loaded.
+     file_code = shared.check_call(cmd, stdout=PIPE).stdout

--- a/patch/emscripten-6.0.6.patch
+++ b/patch/emscripten-6.0.6.patch
@@ -178,3 +178,93 @@ index 8d78776..a82bb98 100644
    if options.preload_files:
      # Preloading files uses --pre-js code that runs before the module is loaded.
      file_code = shared.check_call(cmd, stdout=PIPE).stdout
+diff --git a/tools/system_libs.py b/tools/system_libs.py
+index 0ae34eb..61479ab 100644
+--- a/tools/system_libs.py
++++ b/tools/system_libs.py
+@@ -964,7 +964,6 @@ class libclang_rt_builtins(MTLibrary, SjLjLibrary):
+       '-Wno-unused-but-set-variable',
+   ]
+   src_dir = 'system/lib/compiler-rt/lib/builtins'
+-  profile_src_dir = 'system/lib/compiler-rt/lib/profile'
+   includes = ['system/lib/libc', 'system/lib/compiler-rt/include']
+   excludes = {
+     # gcc_personality_v0.c depends on libunwind, which don't include by default.
+@@ -997,8 +996,6 @@ class libclang_rt_builtins(MTLibrary, SjLjLibrary):
+     'truncxfhf2.c',
+   }
+   src_files = glob_in_path(src_dir, '*.c', excludes=excludes)
+-  src_files += glob_in_path(profile_src_dir, '*.c')
+-  src_files += glob_in_path(profile_src_dir, '*.cpp')
+   src_files += files_in_path(
+       path='system/lib/compiler-rt',
+       filenames=[
+@@ -1012,6 +1009,26 @@ class libclang_rt_builtins(MTLibrary, SjLjLibrary):
+       ])
+ 
+ 
++class libclang_rt_profile(MTLibrary, SjLjLibrary):
++  name = 'libclang_rt.profile'
++  # The profile runtime must remain an optional, lazily-extracted archive.
++  # MAIN_MODULE=1 links normal system libraries with --whole-archive, which
++  # would otherwise enable profiling in every main module.
++  never_force = True
++  force_object_files = True
++
++  cflags = [
++      '-fno-builtin',
++      '-DNDEBUG',
++      '-DCOMPILER_RT_HAS_ATOMICS=1',
++      '-Wno-unused-but-set-variable',
++  ]
++  src_dir = 'system/lib/compiler-rt/lib/profile'
++  includes = ['system/lib/libc', 'system/lib/compiler-rt/include']
++  src_files = glob_in_path(src_dir, '*.c')
++  src_files += glob_in_path(src_dir, '*.cpp')
++
++
+ class libnoexit(Library):
+   name = 'libnoexit'
+   src_dir = 'system/lib/libc'
+@@ -2397,6 +2414,7 @@ def get_libs_to_link():
+     add_library('libclang_rt.builtins')
+     add_sanitizer_libs()
+     add_forced_libs()
++    add_library('libclang_rt.profile')
+     return libs_to_link
+ 
+   if settings.AUTO_NATIVE_LIBRARIES:
+@@ -2510,17 +2528,29 @@ def get_libs_to_link():
+ 
+   add_sanitizer_libs()
+   add_forced_libs()
++  # Keep the profiling runtime available for objects built with profiling
++  # instrumentation.  Normal archive extraction leaves it out otherwise.
++  add_library('libclang_rt.profile')
+   return libs_to_link
+ 
+ 
+ def calculate():
+   libs_to_link = get_libs_to_link()
+ 
+-  # When LINKABLE is set the entire link command line is wrapped in --whole-archive by
+-  # building.link_ldd.  And since --whole-archive/--no-whole-archive processing does not nest we
+-  # shouldn't add any extra `--no-whole-archive` or we will undo the intent of building.link_ldd.
++  # When LINKABLE is set the entire link command line is wrapped in
++  # --whole-archive by building.link_lld.  Keep the profiling runtime outside
++  # that span: only instrumented objects should extract members from it.
+   if settings.LINKABLE or settings.SIDE_MODULE:
+-    return [l[0] for l in libs_to_link]
++    ret = []
++    profile_lib = None
++    for name, _ in libs_to_link:
++      if name == '-lclang_rt.profile':
++        profile_lib = name
++      else:
++        ret.append(name)
++    if profile_lib:
++      ret += ['--no-whole-archive', profile_lib, '--whole-archive']
++    return ret
+ 
+   # Wrap libraries in --whole-archive, as needed.  We need to do this last
+   # since otherwise the abort sorting won't make sense.

--- a/patch/php7.4.patch
+++ b/patch/php7.4.patch
@@ -135,10 +135,15 @@ index cd79475..5c0039d 100644
  
  	if (fastcgi) {
  		/* How many times to run PHP scripts before dying */
-@@ -2709,3 +2713,18 @@ parent_out:
+@@ -2709,3 +2713,23 @@ parent_out:
  	return exit_status;
  }
  /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 +
 +void EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_init(void)
 +{

--- a/patch/php8.0.patch
+++ b/patch/php8.0.patch
@@ -343,10 +343,15 @@ index 0d52941..ac46a7a 100644
  
  	if (fastcgi) {
  		/* How many times to run PHP scripts before dying */
-@@ -2672,3 +2674,18 @@ parent_out:
+@@ -2672,3 +2674,23 @@ parent_out:
  	return exit_status;
  }
  /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 +
 +void EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_init(void)
 +{

--- a/patch/php8.0.patch
+++ b/patch/php8.0.patch
@@ -496,7 +496,7 @@ index ce32caa..160d36f 100644
  } /* }}} */
  
 -int main(int argc, char **argv) /* {{{ */
-+int EMSCRIPTEN_KEEPALIVE main(int argc, char **argv) /* {{{ */
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_phpdbg_main(int argc, char **argv) /* {{{ */
  {
  	sapi_module_struct *phpdbg = &phpdbg_sapi_module;
  	char *sapi_name;

--- a/patch/php8.0.patch
+++ b/patch/php8.0.patch
@@ -665,3 +665,109 @@ index 56fb654..3517ee0 100644
  {
  	/* find cached prompt */
  	if (PHPDBG_G(prompt)[1]) {
+diff --git a/third_party/php8.0-src/ext/iconv/config.m4 b/third_party/php8.0-src/ext/iconv/config.m4
+index ac57c81..d104b2b 100644
+--- a/third_party/php8.0-src/ext/iconv/config.m4
++++ b/third_party/php8.0-src/ext/iconv/config.m4
+@@ -27,21 +27,18 @@ if test "$PHP_ICONV" != "no"; then
+     ])
+ 
+     if test -z "$iconv_impl_name"; then
+-      AC_MSG_CHECKING([if using GNU libiconv])
+-      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+-#include <iconv.h>
+-int main() {
+-  printf("%d", _libiconv_version);
+-  return 0;
+-}
+-      ]])],[
+-        AC_MSG_RESULT(yes)
+-        iconv_impl_name="gnu_libiconv"
+-      ],[
+-        AC_MSG_RESULT(no)
+-      ],[
+-        AC_MSG_RESULT([no, cross-compiling])
++      AC_CACHE_CHECK([if using GNU libiconv], [php_cv_iconv_implementation], [
++        AC_LINK_IFELSE([
++          AC_LANG_PROGRAM([[#include <iconv.h>]], [[(void) _libiconv_version;]])
++        ],[
++          php_cv_iconv_implementation="gnu_libiconv"
++        ],[
++          php_cv_iconv_implementation="unknown"
++        ])
+       ])
++      if test "$php_cv_iconv_implementation" = "gnu_libiconv"; then
++        iconv_impl_name="gnu_libiconv"
++      fi
+     fi
+ 
+     if test -z "$iconv_impl_name"; then
+@@ -85,8 +82,8 @@ int main() {
+         ;;
+     esac
+ 
+-    AC_MSG_CHECKING([if iconv supports errno])
+-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
++    AC_CACHE_CHECK([if iconv supports errno], [php_cv_iconv_errno], [
++      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ #include <iconv.h>
+ #include <errno.h>
+ 
+@@ -103,17 +100,20 @@ int main() {
+   iconv_close( cd );
+   return 2;
+ }
+-    ]])],[
+-      AC_MSG_RESULT(yes)
+-    ],[
+-      AC_MSG_RESULT(no)
+-      AC_MSG_ERROR(iconv does not support errno)
+-    ],[
+-      AC_MSG_RESULT(yes, cross-compiling)
++      ]])],[
++        php_cv_iconv_errno="yes"
++      ],[
++        php_cv_iconv_errno="no"
++      ],[
++        php_cv_iconv_errno="yes"
++      ])
+     ])
++    if test "$php_cv_iconv_errno" != "yes"; then
++      AC_MSG_ERROR(iconv does not support errno)
++    fi
+ 
+-    AC_MSG_CHECKING([if iconv supports //IGNORE])
+-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
++    AC_CACHE_CHECK([if iconv supports //IGNORE], [php_cv_iconv_ignore], [
++      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ #include <iconv.h>
+ #include <stdlib.h>
+ 
+@@ -132,16 +132,19 @@ int main() {
+   }
+   return 0;
+ }
+-   ]])],[
+-      AC_MSG_RESULT(yes)
++      ]])],[
++        php_cv_iconv_ignore="yes"
++      ],[
++        php_cv_iconv_ignore="no"
++      ],[
++        php_cv_iconv_ignore="yes"
++      ])
++    ])
++    if test "$php_cv_iconv_ignore" = "yes"; then
+       AC_DEFINE([ICONV_BROKEN_IGNORE],0,[Whether iconv supports IGNORE])
+-    ],[
+-      AC_MSG_RESULT(no)
++    else
+       AC_DEFINE([ICONV_BROKEN_IGNORE],1,[Whether iconv supports IGNORE])
+-    ],[
+-      AC_MSG_RESULT(no, cross-compiling)
+-      AC_DEFINE([ICONV_BROKEN_IGNORE],0,[Whether iconv supports IGNORE])
+-    ])
++    fi
+ 
+     LDFLAGS="$save_LDFLAGS"
+     CFLAGS="$save_CFLAGS"

--- a/patch/php8.0.patch
+++ b/patch/php8.0.patch
@@ -367,6 +367,31 @@ index 0d52941..ac46a7a 100644
 +{
 +	return _sapi_cgi_putenv(name, strlen(name), value);
 +}
+diff --git a/third_party/php8.0-src/sapi/cli/php_cli.c b/third_party/php8.0-src/sapi/cli/php_cli.c
+--- a/third_party/php8.0-src/sapi/cli/php_cli.c
++++ b/third_party/php8.0-src/sapi/cli/php_cli.c
+@@ -18,6 +18,7 @@
+    +----------------------------------------------------------------------+
+ */
+ 
++#include <emscripten.h>
+ #include "php.h"
+ #include "php_globals.h"
+ #include "php_variables.h"
+@@ -1375,3 +1376,12 @@ int main(int argc, char *argv[])
++#ifdef __EMSCRIPTEN__
++	return exit_status;
++#else
+-	exit(exit_status);
++	exit(exit_status);
++#endif
+ }
+ /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cli_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 diff --git a/third_party/php8.0-src/sapi/cli/Makefile.frag b/third_party/php8.0-src/sapi/cli/Makefile.frag
 index aa1d642..649533d 100644
 --- a/third_party/php8.0-src/sapi/cli/Makefile.frag

--- a/patch/php8.1.patch
+++ b/patch/php8.1.patch
@@ -323,10 +323,15 @@ index 499a793..b048346 100644
  
  	if (fastcgi) {
  		/* How many times to run PHP scripts before dying */
-@@ -2665,3 +2667,18 @@ parent_out:
+@@ -2665,3 +2667,23 @@ parent_out:
  	return exit_status;
  }
  /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 +
 +void EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_init(void)
 +{

--- a/patch/php8.1.patch
+++ b/patch/php8.1.patch
@@ -641,3 +641,109 @@ index f638d60..4c50f0f 100644
  {
  	/* find cached prompt */
  	if (PHPDBG_G(prompt)[1]) {
+diff --git a/third_party/php8.1-src/ext/iconv/config.m4 b/third_party/php8.1-src/ext/iconv/config.m4
+index ac57c81..d104b2b 100644
+--- a/third_party/php8.1-src/ext/iconv/config.m4
++++ b/third_party/php8.1-src/ext/iconv/config.m4
+@@ -27,21 +27,18 @@ if test "$PHP_ICONV" != "no"; then
+     ])
+ 
+     if test -z "$iconv_impl_name"; then
+-      AC_MSG_CHECKING([if using GNU libiconv])
+-      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+-#include <iconv.h>
+-int main() {
+-  printf("%d", _libiconv_version);
+-  return 0;
+-}
+-      ]])],[
+-        AC_MSG_RESULT(yes)
+-        iconv_impl_name="gnu_libiconv"
+-      ],[
+-        AC_MSG_RESULT(no)
+-      ],[
+-        AC_MSG_RESULT([no, cross-compiling])
++      AC_CACHE_CHECK([if using GNU libiconv], [php_cv_iconv_implementation], [
++        AC_LINK_IFELSE([
++          AC_LANG_PROGRAM([[#include <iconv.h>]], [[(void) _libiconv_version;]])
++        ],[
++          php_cv_iconv_implementation="gnu_libiconv"
++        ],[
++          php_cv_iconv_implementation="unknown"
++        ])
+       ])
++      if test "$php_cv_iconv_implementation" = "gnu_libiconv"; then
++        iconv_impl_name="gnu_libiconv"
++      fi
+     fi
+ 
+     if test -z "$iconv_impl_name"; then
+@@ -85,8 +82,8 @@ int main() {
+         ;;
+     esac
+ 
+-    AC_MSG_CHECKING([if iconv supports errno])
+-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
++    AC_CACHE_CHECK([if iconv supports errno], [php_cv_iconv_errno], [
++      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ #include <iconv.h>
+ #include <errno.h>
+ 
+@@ -103,17 +100,20 @@ int main() {
+   iconv_close( cd );
+   return 2;
+ }
+-    ]])],[
+-      AC_MSG_RESULT(yes)
+-    ],[
+-      AC_MSG_RESULT(no)
+-      AC_MSG_ERROR(iconv does not support errno)
+-    ],[
+-      AC_MSG_RESULT(yes, cross-compiling)
++      ]])],[
++        php_cv_iconv_errno="yes"
++      ],[
++        php_cv_iconv_errno="no"
++      ],[
++        php_cv_iconv_errno="yes"
++      ])
+     ])
++    if test "$php_cv_iconv_errno" != "yes"; then
++      AC_MSG_ERROR(iconv does not support errno)
++    fi
+ 
+-    AC_MSG_CHECKING([if iconv supports //IGNORE])
+-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
++    AC_CACHE_CHECK([if iconv supports //IGNORE], [php_cv_iconv_ignore], [
++      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ #include <iconv.h>
+ #include <stdlib.h>
+ 
+@@ -132,16 +132,19 @@ int main() {
+   }
+   return 0;
+ }
+-   ]])],[
+-      AC_MSG_RESULT(yes)
++      ]])],[
++        php_cv_iconv_ignore="yes"
++      ],[
++        php_cv_iconv_ignore="no"
++      ],[
++        php_cv_iconv_ignore="yes"
++      ])
++    ])
++    if test "$php_cv_iconv_ignore" = "yes"; then
+       AC_DEFINE([ICONV_BROKEN_IGNORE],0,[Whether iconv supports IGNORE])
+-    ],[
+-      AC_MSG_RESULT(no)
++    else
+       AC_DEFINE([ICONV_BROKEN_IGNORE],1,[Whether iconv supports IGNORE])
+-    ],[
+-      AC_MSG_RESULT(no, cross-compiling)
+-      AC_DEFINE([ICONV_BROKEN_IGNORE],0,[Whether iconv supports IGNORE])
+-    ])
++    fi
+ 
+     LDFLAGS="$save_LDFLAGS"
+     CFLAGS="$save_CFLAGS"

--- a/patch/php8.1.patch
+++ b/patch/php8.1.patch
@@ -347,6 +347,31 @@ index 499a793..b048346 100644
 +{
 +	return _sapi_cgi_putenv(name, strlen(name), value);
 +}
+diff --git a/third_party/php8.1-src/sapi/cli/php_cli.c b/third_party/php8.1-src/sapi/cli/php_cli.c
+--- a/third_party/php8.1-src/sapi/cli/php_cli.c
++++ b/third_party/php8.1-src/sapi/cli/php_cli.c
+@@ -18,6 +18,7 @@
+    +----------------------------------------------------------------------+
+ */
+ 
++#include <emscripten.h>
+ #include "php.h"
+ #include "php_globals.h"
+ #include "php_variables.h"
+@@ -1405,3 +1406,12 @@ int main(int argc, char *argv[])
++#ifdef __EMSCRIPTEN__
++	return exit_status;
++#else
+-	exit(exit_status);
++	exit(exit_status);
++#endif
+ }
+ /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cli_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 diff --git a/third_party/php8.1-src/sapi/cli/Makefile.frag b/third_party/php8.1-src/sapi/cli/Makefile.frag
 index aa1d642..649533d 100644
 --- a/third_party/php8.1-src/sapi/cli/Makefile.frag

--- a/patch/php8.1.patch
+++ b/patch/php8.1.patch
@@ -476,7 +476,7 @@ index e1824ec..96af7bc 100644
  } /* }}} */
  
 -int main(int argc, char **argv) /* {{{ */
-+int EMSCRIPTEN_KEEPALIVE main(int argc, char **argv) /* {{{ */
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_phpdbg_main(int argc, char **argv) /* {{{ */
  {
  	sapi_module_struct *phpdbg = &phpdbg_sapi_module;
  	char *sapi_name;

--- a/patch/php8.2.patch
+++ b/patch/php8.2.patch
@@ -602,7 +602,7 @@ index d4ffcdf..9b1b339 100644
  } /* }}} */
  
 -int main(int argc, char **argv) /* {{{ */
-+int EMSCRIPTEN_KEEPALIVE main(int argc, char **argv) /* {{{ */
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_phpdbg_main(int argc, char **argv) /* {{{ */
  {
  	sapi_module_struct *phpdbg = &phpdbg_sapi_module;
  	char *sapi_name;

--- a/patch/php8.2.patch
+++ b/patch/php8.2.patch
@@ -449,10 +449,15 @@ index b454680..e98bf3e 100644
  
  	if (fastcgi) {
  		/* How many times to run PHP scripts before dying */
-@@ -2640,3 +2643,18 @@ consult the installation file that came with this distribution, or visit \n\
+@@ -2640,3 +2643,23 @@ consult the installation file that came with this distribution, or visit \n\
  	return exit_status;
  }
  /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 +
 +void EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_init(void)
 +{

--- a/patch/php8.2.patch
+++ b/patch/php8.2.patch
@@ -755,3 +755,109 @@ index f638d60..4c50f0f 100644
  {
  	/* find cached prompt */
  	if (PHPDBG_G(prompt)[1]) {
+diff --git a/third_party/php8.2-src/ext/iconv/config.m4 b/third_party/php8.2-src/ext/iconv/config.m4
+index ac57c81..d104b2b 100644
+--- a/third_party/php8.2-src/ext/iconv/config.m4
++++ b/third_party/php8.2-src/ext/iconv/config.m4
+@@ -27,21 +27,18 @@ if test "$PHP_ICONV" != "no"; then
+     ])
+ 
+     if test -z "$iconv_impl_name"; then
+-      AC_MSG_CHECKING([if using GNU libiconv])
+-      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+-#include <iconv.h>
+-int main() {
+-  printf("%d", _libiconv_version);
+-  return 0;
+-}
+-      ]])],[
+-        AC_MSG_RESULT(yes)
+-        iconv_impl_name="gnu_libiconv"
+-      ],[
+-        AC_MSG_RESULT(no)
+-      ],[
+-        AC_MSG_RESULT([no, cross-compiling])
++      AC_CACHE_CHECK([if using GNU libiconv], [php_cv_iconv_implementation], [
++        AC_LINK_IFELSE([
++          AC_LANG_PROGRAM([[#include <iconv.h>]], [[(void) _libiconv_version;]])
++        ],[
++          php_cv_iconv_implementation="gnu_libiconv"
++        ],[
++          php_cv_iconv_implementation="unknown"
++        ])
+       ])
++      if test "$php_cv_iconv_implementation" = "gnu_libiconv"; then
++        iconv_impl_name="gnu_libiconv"
++      fi
+     fi
+ 
+     if test -z "$iconv_impl_name"; then
+@@ -85,8 +82,8 @@ int main() {
+         ;;
+     esac
+ 
+-    AC_MSG_CHECKING([if iconv supports errno])
+-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
++    AC_CACHE_CHECK([if iconv supports errno], [php_cv_iconv_errno], [
++      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ #include <iconv.h>
+ #include <errno.h>
+ 
+@@ -103,17 +100,20 @@ int main() {
+   iconv_close( cd );
+   return 2;
+ }
+-    ]])],[
+-      AC_MSG_RESULT(yes)
+-    ],[
+-      AC_MSG_RESULT(no)
+-      AC_MSG_ERROR(iconv does not support errno)
+-    ],[
+-      AC_MSG_RESULT(yes, cross-compiling)
++      ]])],[
++        php_cv_iconv_errno="yes"
++      ],[
++        php_cv_iconv_errno="no"
++      ],[
++        php_cv_iconv_errno="yes"
++      ])
+     ])
++    if test "$php_cv_iconv_errno" != "yes"; then
++      AC_MSG_ERROR(iconv does not support errno)
++    fi
+ 
+-    AC_MSG_CHECKING([if iconv supports //IGNORE])
+-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
++    AC_CACHE_CHECK([if iconv supports //IGNORE], [php_cv_iconv_ignore], [
++      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ #include <iconv.h>
+ #include <stdlib.h>
+ 
+@@ -132,16 +132,19 @@ int main() {
+   }
+   return 0;
+ }
+-   ]])],[
+-      AC_MSG_RESULT(yes)
++      ]])],[
++        php_cv_iconv_ignore="yes"
++      ],[
++        php_cv_iconv_ignore="no"
++      ],[
++        php_cv_iconv_ignore="yes"
++      ])
++    ])
++    if test "$php_cv_iconv_ignore" = "yes"; then
+       AC_DEFINE([ICONV_BROKEN_IGNORE],0,[Whether iconv supports IGNORE])
+-    ],[
+-      AC_MSG_RESULT(no)
++    else
+       AC_DEFINE([ICONV_BROKEN_IGNORE],1,[Whether iconv supports IGNORE])
+-    ],[
+-      AC_MSG_RESULT(no, cross-compiling)
+-      AC_DEFINE([ICONV_BROKEN_IGNORE],0,[Whether iconv supports IGNORE])
+-    ])
++    fi
+ 
+     LDFLAGS="$save_LDFLAGS"
+     CFLAGS="$save_CFLAGS"

--- a/patch/php8.2.patch
+++ b/patch/php8.2.patch
@@ -473,6 +473,31 @@ index b454680..e98bf3e 100644
 +{
 +	return _sapi_cgi_putenv(name, strlen(name), value);
 +}
+diff --git a/third_party/php8.2-src/sapi/cli/php_cli.c b/third_party/php8.2-src/sapi/cli/php_cli.c
+--- a/third_party/php8.2-src/sapi/cli/php_cli.c
++++ b/third_party/php8.2-src/sapi/cli/php_cli.c
+@@ -18,6 +18,7 @@
+    +----------------------------------------------------------------------+
+ */
+ 
++#include <emscripten.h>
+ #include "php.h"
+ #include "php_globals.h"
+ #include "php_variables.h"
+@@ -1369,3 +1370,12 @@ int main(int argc, char *argv[])
++#ifdef __EMSCRIPTEN__
++	return exit_status;
++#else
+-	exit(exit_status);
++	exit(exit_status);
++#endif
+ }
+ /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cli_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 diff --git a/third_party/php8.2-src/sapi/cli/Makefile.frag b/third_party/php8.2-src/sapi/cli/Makefile.frag
 index aa1d642..649533d 100644
 --- a/third_party/php8.2-src/sapi/cli/Makefile.frag

--- a/patch/php8.3.patch
+++ b/patch/php8.3.patch
@@ -725,3 +725,110 @@ index 964d82e..361821c 100644
  {
  	/* find cached prompt */
  	if (PHPDBG_G(prompt)[1]) {
+diff --git a/third_party/php8.3-src/ext/iconv/config.m4 b/third_party/php8.3-src/ext/iconv/config.m4
+index 3cf400f..740b755 100644
+--- a/third_party/php8.3-src/ext/iconv/config.m4
++++ b/third_party/php8.3-src/ext/iconv/config.m4
+@@ -27,22 +27,18 @@ if test "$PHP_ICONV" != "no"; then
+     ])
+ 
+     if test -z "$iconv_impl_name"; then
+-      AC_MSG_CHECKING([if using GNU libiconv])
+-      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+-#include <iconv.h>
+-#include <stdio.h>
+-int main(void) {
+-  printf("%d", _libiconv_version);
+-  return 0;
+-}
+-      ]])],[
+-        AC_MSG_RESULT(yes)
+-        iconv_impl_name="gnu_libiconv"
+-      ],[
+-        AC_MSG_RESULT(no)
+-      ],[
+-        AC_MSG_RESULT([no, cross-compiling])
++      AC_CACHE_CHECK([if using GNU libiconv], [php_cv_iconv_implementation], [
++        AC_LINK_IFELSE([
++          AC_LANG_PROGRAM([[#include <iconv.h>]], [[(void) _libiconv_version;]])
++        ],[
++          php_cv_iconv_implementation="gnu_libiconv"
++        ],[
++          php_cv_iconv_implementation="unknown"
++        ])
+       ])
++      if test "$php_cv_iconv_implementation" = "gnu_libiconv"; then
++        iconv_impl_name="gnu_libiconv"
++      fi
+     fi
+ 
+     if test -z "$iconv_impl_name"; then
+@@ -86,8 +82,8 @@ int main(void) {
+         ;;
+     esac
+ 
+-    AC_MSG_CHECKING([if iconv supports errno])
+-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
++    AC_CACHE_CHECK([if iconv supports errno], [php_cv_iconv_errno], [
++      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ #include <iconv.h>
+ #include <errno.h>
+ 
+@@ -104,17 +100,20 @@ int main(void) {
+   iconv_close( cd );
+   return 2;
+ }
+-    ]])],[
+-      AC_MSG_RESULT(yes)
+-    ],[
+-      AC_MSG_RESULT(no)
+-      AC_MSG_ERROR(iconv does not support errno)
+-    ],[
+-      AC_MSG_RESULT(yes, cross-compiling)
++      ]])],[
++        php_cv_iconv_errno="yes"
++      ],[
++        php_cv_iconv_errno="no"
++      ],[
++        php_cv_iconv_errno="yes"
++      ])
+     ])
++    if test "$php_cv_iconv_errno" != "yes"; then
++      AC_MSG_ERROR(iconv does not support errno)
++    fi
+ 
+-    AC_MSG_CHECKING([if iconv supports //IGNORE])
+-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
++    AC_CACHE_CHECK([if iconv supports //IGNORE], [php_cv_iconv_ignore], [
++      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ #include <iconv.h>
+ #include <stdlib.h>
+ 
+@@ -133,16 +132,19 @@ int main(void) {
+   }
+   return 0;
+ }
+-   ]])],[
+-      AC_MSG_RESULT(yes)
++      ]])],[
++        php_cv_iconv_ignore="yes"
++      ],[
++        php_cv_iconv_ignore="no"
++      ],[
++        php_cv_iconv_ignore="yes"
++      ])
++    ])
++    if test "$php_cv_iconv_ignore" = "yes"; then
+       AC_DEFINE([ICONV_BROKEN_IGNORE],0,[Whether iconv supports IGNORE])
+-    ],[
+-      AC_MSG_RESULT(no)
++    else
+       AC_DEFINE([ICONV_BROKEN_IGNORE],1,[Whether iconv supports IGNORE])
+-    ],[
+-      AC_MSG_RESULT(no, cross-compiling)
+-      AC_DEFINE([ICONV_BROKEN_IGNORE],0,[Whether iconv supports IGNORE])
+-    ])
++    fi
+ 
+     LDFLAGS="$save_LDFLAGS"
+     CFLAGS="$save_CFLAGS"

--- a/patch/php8.3.patch
+++ b/patch/php8.3.patch
@@ -407,10 +407,15 @@ index 364758c..a969bc8 100644
  
  	if (fastcgi) {
  		/* How many times to run PHP scripts before dying */
-@@ -2676,3 +2679,18 @@ consult the installation file that came with this distribution, or visit \n\
+@@ -2676,3 +2679,23 @@ consult the installation file that came with this distribution, or visit \n\
  	return exit_status;
  }
  /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 +
 +void EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_init(void)
 +{

--- a/patch/php8.3.patch
+++ b/patch/php8.3.patch
@@ -431,6 +431,31 @@ index 364758c..a969bc8 100644
 +{
 +	return _sapi_cgi_putenv(name, strlen(name), value);
 +}
+diff --git a/third_party/php8.3-src/sapi/cli/php_cli.c b/third_party/php8.3-src/sapi/cli/php_cli.c
+--- a/third_party/php8.3-src/sapi/cli/php_cli.c
++++ b/third_party/php8.3-src/sapi/cli/php_cli.c
+@@ -18,6 +18,7 @@
+    +----------------------------------------------------------------------+
+ */
+ 
++#include <emscripten.h>
+ #include "php.h"
+ #include "php_globals.h"
+ #include "php_variables.h"
+@@ -1376,3 +1377,12 @@ int main(int argc, char *argv[])
++#ifdef __EMSCRIPTEN__
++	return exit_status;
++#else
+-	exit(exit_status);
++	exit(exit_status);
++#endif
+ }
+ /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cli_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 diff --git a/third_party/php8.3-src/sapi/cli/Makefile.frag b/third_party/php8.3-src/sapi/cli/Makefile.frag
 index aa1d642..649533d 100644
 --- a/third_party/php8.3-src/sapi/cli/Makefile.frag

--- a/patch/php8.3.patch
+++ b/patch/php8.3.patch
@@ -560,7 +560,7 @@ index a583854..435a42c 100644
  } /* }}} */
  
 -int main(int argc, char **argv) /* {{{ */
-+int EMSCRIPTEN_KEEPALIVE main(int argc, char **argv) /* {{{ */
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_phpdbg_main(int argc, char **argv) /* {{{ */
  {
  	sapi_module_struct *phpdbg = &phpdbg_sapi_module;
  	char *sapi_name;

--- a/patch/php8.4.patch
+++ b/patch/php8.4.patch
@@ -391,6 +391,31 @@ index 0e7b300..3652b52 100644
 +{
 +	return _sapi_cgi_putenv(name, strlen(name), value);
 +}
+diff --git a/third_party/php8.4-src/sapi/cli/php_cli.c b/third_party/php8.4-src/sapi/cli/php_cli.c
+--- a/third_party/php8.4-src/sapi/cli/php_cli.c
++++ b/third_party/php8.4-src/sapi/cli/php_cli.c
+@@ -18,6 +18,7 @@
+    +----------------------------------------------------------------------+
+ */
+ 
++#include <emscripten.h>
+ #include "php.h"
+ #include "php_globals.h"
+ #include "php_variables.h"
+@@ -1346,3 +1347,12 @@ int main(int argc, char *argv[])
++#ifdef __EMSCRIPTEN__
++	return exit_status;
++#else
+-	exit(exit_status);
++	exit(exit_status);
++#endif
+ }
+ /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cli_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 diff --git a/third_party/php8.4-src/sapi/cli/Makefile.frag b/third_party/php8.4-src/sapi/cli/Makefile.frag
 index aa1d642..649533d 100644
 --- a/third_party/php8.4-src/sapi/cli/Makefile.frag

--- a/patch/php8.4.patch
+++ b/patch/php8.4.patch
@@ -367,10 +367,15 @@ index 0e7b300..3652b52 100644
  
  	if (fastcgi) {
  		/* How many times to run PHP scripts before dying */
-@@ -2681,3 +2684,18 @@ consult the installation file that came with this distribution, or visit \n\
+@@ -2681,3 +2684,23 @@ consult the installation file that came with this distribution, or visit \n\
  	return exit_status;
  }
  /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 +
 +void EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_init(void)
 +{

--- a/patch/php8.4.patch
+++ b/patch/php8.4.patch
@@ -520,7 +520,7 @@ index 76b3c7f..6cf12a9 100644
  } /* }}} */
  
 -int main(int argc, char **argv) /* {{{ */
-+int EMSCRIPTEN_KEEPALIVE main(int argc, char **argv) /* {{{ */
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_phpdbg_main(int argc, char **argv) /* {{{ */
  {
  	sapi_module_struct *phpdbg = &phpdbg_sapi_module;
  	char *sapi_name;

--- a/patch/php8.5.patch
+++ b/patch/php8.5.patch
@@ -606,7 +606,7 @@ index 4ef83be..3875975 100644
  } /* }}} */
  
 -int main(int argc, char **argv) /* {{{ */
-+int EMSCRIPTEN_KEEPALIVE main(int argc, char **argv) /* {{{ */
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_phpdbg_main(int argc, char **argv) /* {{{ */
  {
  	sapi_module_struct *phpdbg = &phpdbg_sapi_module;
  	char *sapi_name;

--- a/patch/php8.5.patch
+++ b/patch/php8.5.patch
@@ -477,6 +477,31 @@ index 6db96a4..1ff31d7 100644
 +{
 +	return _sapi_cgi_putenv(name, strlen(name), value);
 +}
+diff --git a/third_party/php8.5-src/sapi/cli/php_cli.c b/third_party/php8.5-src/sapi/cli/php_cli.c
+--- a/third_party/php8.5-src/sapi/cli/php_cli.c
++++ b/third_party/php8.5-src/sapi/cli/php_cli.c
+@@ -18,6 +18,7 @@
+    +----------------------------------------------------------------------+
+ */
+ 
++#include <emscripten.h>
+ #include "php.h"
+ #include "php_globals.h"
+ #include "php_variables.h"
+@@ -1398,3 +1399,12 @@ int main(int argc, char *argv[])
++#ifdef __EMSCRIPTEN__
++	return exit_status;
++#else
+-	exit(exit_status);
++	exit(exit_status);
++#endif
+ }
+ /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cli_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 diff --git a/third_party/php8.5-src/sapi/cli/Makefile.frag b/third_party/php8.5-src/sapi/cli/Makefile.frag
 index aa1d642..649533d 100644
 --- a/third_party/php8.5-src/sapi/cli/Makefile.frag

--- a/patch/php8.5.patch
+++ b/patch/php8.5.patch
@@ -453,10 +453,15 @@ index 6db96a4..1ff31d7 100644
  	if (fastcgi) {
  		/* How many times to run PHP scripts before dying */
  		if (getenv("PHP_FCGI_MAX_REQUESTS")) {
-@@ -2677,3 +2680,18 @@ consult the installation file that came with this distribution, or visit \n\
+@@ -2677,3 +2680,23 @@ consult the installation file that came with this distribution, or visit \n\
  	return exit_status;
  }
  /* }}} */
++
++int EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_main(int argc, char **argv)
++{
++	return main(argc, argv);
++}
 +
 +void EMSCRIPTEN_KEEPALIVE wasm_sapi_cgi_init(void)
 +{

--- a/source/PhpBase.mjs
+++ b/source/PhpBase.mjs
@@ -10,6 +10,9 @@ const NUM = 'number';
 const normalizeRuntimeModule = runtime => runtime && typeof runtime === 'object' && 'default' in runtime
 	? runtime
 	: {default: runtime};
+const instantiateRuntimeModule = (Runtime, args) => /^class\s/.test(Function.prototype.toString.call(Runtime))
+	? new Runtime(args)
+	: Runtime(args);
 
 /**
  * Base PHP runtime wrapper shared by the environment-specific adapters.
@@ -129,7 +132,7 @@ export class PhpBase extends EventTarget
 
 		const phpArgs = Object.assign({}, defaults, phpSettings, args, fixed);
 
-		this.binary = phpBinLoader.then(normalizeRuntimeModule).then(({default: PHP}) => new PHP(phpArgs)).then(async php => {
+		this.binary = phpBinLoader.then(normalizeRuntimeModule).then(({default: PHP}) => instantiateRuntimeModule(PHP, phpArgs)).then(async php => {
 			await php.ccall(
 				'pib_storage_init'
 				, NUM

--- a/source/PhpCgiBase.mjs
+++ b/source/PhpCgiBase.mjs
@@ -25,6 +25,9 @@ import { resolveDependencies } from './resolveDependencies.mjs';
 
 const STR = 'string';
 const NUM = 'number';
+const instantiateRuntimeModule = (Runtime, args) => /^class\s/.test(Function.prototype.toString.call(Runtime))
+	? new Runtime(args)
+	: Runtime(args);
 
 const putEnv = (php, key, value) => php.ccall(
 	'wasm_sapi_cgi_putenv'
@@ -591,7 +594,7 @@ export class PhpCgiBase
 			, locateFile
 		};
 
-		return this.binary = this.binLoader.then(({default: PHP}) => new PHP(phpArgs)).then(async php => {
+		return this.binary = this.binLoader.then(({default: PHP}) => instantiateRuntimeModule(PHP, phpArgs)).then(async php => {
 			await php.ccall(
 				'pib_storage_init'
 				, NUM
@@ -866,10 +869,10 @@ export class PhpCgiBase
 				this.output = [];
 
 				exitCode = Number(await php.ccall(
-					'main'
+					'wasm_sapi_cgi_main'
 					, 'number'
-					, ['number', 'string']
-					, []
+					, ['number', 'number']
+					, [0, 0]
 					, {async: true}
 				));
 

--- a/source/PhpCgiBase.mjs
+++ b/source/PhpCgiBase.mjs
@@ -637,7 +637,7 @@ export class PhpCgiBase
 				}
 				else if(typeof lib === 'object' && lib.ini)
 				{
-					return `extension=${String(lib.url).split('/').pop()}`;
+					return `extension=${lib.name ?? String(lib.url).split('/').pop()}`;
 				}
 			});
 

--- a/source/PhpCgiWebBase.mjs
+++ b/source/PhpCgiWebBase.mjs
@@ -4,6 +4,9 @@ import { resolveDependencies } from './resolveDependencies.mjs';
 
 const STR = 'string';
 const NUM = 'number';
+const instantiateRuntimeModule = (Runtime, args) => /^class\s/.test(Function.prototype.toString.call(Runtime))
+	? new Runtime(args)
+	: Runtime(args);
 
 /**
  * Browser-specific CGI wrapper with FS transaction support.
@@ -114,7 +117,7 @@ export class PhpCgiWebBase extends PhpCgiBase
 
 			const {default: PHP} = await this.binLoader;
 
-			const php = await new PHP(phpArgs);
+			const php = await instantiateRuntimeModule(PHP, phpArgs);
 
 			await php.ccall(
 				'pib_storage_init'

--- a/source/PhpCgiWebBase.mjs
+++ b/source/PhpCgiWebBase.mjs
@@ -161,7 +161,7 @@ export class PhpCgiWebBase extends PhpCgiBase
 				}
 				else if(typeof lib === 'object' && lib.ini)
 				{
-					return `extension=${String(lib.url).split('/').pop()}`;
+					return `extension=${lib.name ?? String(lib.url).split('/').pop()}`;
 				}
 			});
 

--- a/source/PhpCliNode.mjs
+++ b/source/PhpCliNode.mjs
@@ -185,17 +185,19 @@ export class PhpCliNode extends PhpBase
 			php.stringToUTF8(part, loc, len);
 			return loc;
 		});
-		const arLoc = php._malloc(4 * ptrs.length);
+		const arLoc = php._malloc(4 * (ptrs.length + 1));
 
 		for(const [index, ptr] of ptrs.entries())
 		{
 			php.setValue(arLoc + 4 * index, ptr, '*');
 		}
 
+		php.setValue(arLoc + 4 * ptrs.length, 0, '*');
+
 		try
 		{
 			return await php.ccall(
-				'main'
+				'wasm_sapi_cli_main'
 				, NUM
 				, [NUM, NUM]
 				, [ptrs.length, arLoc]

--- a/source/PhpCliWeb.mjs
+++ b/source/PhpCliWeb.mjs
@@ -161,17 +161,19 @@ export class PhpCliWeb extends PhpBase
 			return loc;
 		});
 
-		const arLoc = php._malloc(4 * ptrs.length);
+		const arLoc = php._malloc(4 * (ptrs.length + 1));
 
 		for(const [i, ptr] of ptrs.entries())
 		{
 			php.setValue(arLoc + 4 * i, ptr, '*');
 		}
 
+		php.setValue(arLoc + 4 * ptrs.length, 0, '*');
+
 		try
 		{
 			return await php.ccall(
-				'main'
+				'wasm_sapi_cli_main'
 				, NUM
 				, [NUM, NUM]
 				, [ptrs.length, arLoc]

--- a/source/PhpDbgNode.mjs
+++ b/source/PhpDbgNode.mjs
@@ -155,17 +155,19 @@ export class PhpDbgNode extends PhpBase
 			php.stringToUTF8(part, loc, len);
 			return loc;
 		});
-		const arLoc = php._malloc(4 * ptrs.length);
+		const arLoc = php._malloc(4 * (ptrs.length + 1));
 
 		for(const [index, ptr] of ptrs.entries())
 		{
 			php.setValue(arLoc + 4 * index, ptr, '*');
 		}
 
+		php.setValue(arLoc + 4 * ptrs.length, 0, '*');
+
 		try
 		{
 			const process = php.ccall(
-				'main'
+				'wasm_sapi_phpdbg_main'
 				, NUM
 				, [NUM, NUM]
 				, [ptrs.length, arLoc]

--- a/source/PhpDbgWeb.mjs
+++ b/source/PhpDbgWeb.mjs
@@ -134,17 +134,19 @@ export class PhpDbgWeb extends PhpBase
 			return loc;
 		});
 
-		const arLoc = php._malloc(4 * ptrs.length);
+		const arLoc = php._malloc(4 * (ptrs.length + 1));
 
 		for(const [i, ptr] of ptrs.entries())
 		{
 			php.setValue(arLoc + 4 * i, ptr, '*');
 		}
 
+		php.setValue(arLoc + 4 * ptrs.length, 0, '*');
+
 		try
 		{
 			const process = php.ccall(
-				'main'
+				'wasm_sapi_phpdbg_main'
 				, NUM
 				, [NUM, NUM]
 				, [ptrs.length, arLoc]

--- a/test/browser/demo-web-artifact.spec.mjs
+++ b/test/browser/demo-web-artifact.spec.mjs
@@ -72,7 +72,7 @@ test('debug preview boots php-dbg', async ({ page }) => {
 	});
 });
 
-test('select framework registers the service worker', async ({ page }) => {
+test('select framework service worker serves CGI', async ({ page }) => {
 	await page.goto('select-framework.html', {waitUntil: 'domcontentloaded'});
 
 	await expect(page.getByText('Select a Framework:')).toBeVisible({ timeout: 180000 });
@@ -100,4 +100,11 @@ test('select framework registers the service worker', async ({ page }) => {
 		}),
 		{ timeout: 180000 }
 	).toContain('/php-wasm/cgi-worker.js');
+
+	const response = await page.goto('cgi-bin/test/hello-world.php', {
+		waitUntil: 'domcontentloaded'
+	});
+
+	expect(response?.status()).toBe(200);
+	await expect(page.locator('body')).toContainText('Hello, World!', { timeout: 180000 });
 });

--- a/test/cli-node/cli-node.test.mjs
+++ b/test/cli-node/cli-node.test.mjs
@@ -1437,6 +1437,23 @@ test('runs a CLI script in Node', async () => {
 	assert.equal(stdErr(), '');
 });
 
+test('returns the PHP CLI exit status', async () => {
+	const php = new PhpCliNode(nodeRuntimeOptions({
+		runtime: 'cli',
+		code: 'exit(7);'
+		, version
+	}));
+	const {stdOut, stdErr} = attachOutput(php);
+
+	await php.binary;
+
+	const exitCode = await php.run();
+
+	assert.equal(exitCode, 7);
+	assert.equal(stdOut(), '');
+	assert.equal(stdErr(), '');
+});
+
 test(`loads the requested CLI runtime version (${version})`, async () => {
 	const php = new PhpCliNode(nodeRuntimeOptions({
 		runtime: 'cli',

--- a/test/download-retry.test.mjs
+++ b/test/download-retry.test.mjs
@@ -1,0 +1,145 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const retryScript = path.join(repoRoot, '.github/bin/retry-download.sh');
+
+/**
+ * Write an executable fixture.
+ * @param {string} filePath Destination path.
+ * @param {string} contents Fixture contents.
+ * @returns {void} Nothing.
+ */
+function writeExecutable(filePath, contents)
+{
+	fs.writeFileSync(filePath, contents, 'utf8');
+	fs.chmodSync(filePath, 0o755);
+}
+
+/**
+ * Run retry-download against a fake curl command.
+ * @param {import('node:test').TestContext} t Test context.
+ * @param {string} curlBody Fake curl implementation body.
+ * @param {number} maxAttempts Maximum attempts.
+ * @param {string | undefined} initialContents Existing output contents.
+ * @returns {{result: import('node:child_process').SpawnSyncReturns<string>, attempts: number, outputFile: string, workspaceDir: string}} Retry result and fixture paths.
+ */
+function runRetry(t, curlBody, maxAttempts = 3, initialContents = undefined)
+{
+	const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'php-wasm-download-retry-'));
+	const binDir = path.join(workspaceDir, 'bin');
+	const countFile = path.join(workspaceDir, 'attempts');
+	const outputFile = path.join(workspaceDir, 'archive.tgz');
+
+	t.after(() => {
+		fs.rmSync(workspaceDir, { recursive: true, force: true });
+	});
+
+	fs.mkdirSync(binDir, { recursive: true });
+	if(initialContents !== undefined)
+	{
+		fs.writeFileSync(outputFile, initialContents, 'utf8');
+	}
+
+	writeExecutable(
+		path.join(binDir, 'curl'),
+		[
+			'#!/usr/bin/env bash'
+			, 'set -euo pipefail'
+			, 'count=0'
+			, 'output_file='
+			, 'if [[ -f "${DOWNLOAD_TEST_COUNT}" ]]; then'
+			, '\tcount="$(<"${DOWNLOAD_TEST_COUNT}")"'
+			, 'fi'
+			, 'count=$((count + 1))'
+			, 'printf \'%s\\n\' "${count}" > "${DOWNLOAD_TEST_COUNT}"'
+			, 'while (( $# > 0 )); do'
+			, '\tif [[ "$1" == --output ]]; then'
+			, '\t\toutput_file="$2"'
+			, '\t\tshift 2'
+			, '\t\tcontinue'
+			, '\tfi'
+			, '\tshift'
+			, 'done'
+			, curlBody
+			, ''
+		].join('\n')
+	);
+
+	const result = spawnSync(
+		'bash',
+		[retryScript, 'https://example.invalid/archive.tgz', outputFile],
+		{
+			cwd: repoRoot
+			, encoding: 'utf8'
+			, env: {
+				...process.env
+				, PATH: `${binDir}:${process.env.PATH ?? ''}`
+				, DOWNLOAD_TEST_COUNT: countFile
+				, DOWNLOAD_RETRY_ATTEMPTS: String(maxAttempts)
+				, DOWNLOAD_RETRY_DELAY_SECONDS: '0'
+			}
+		}
+	);
+
+	return {
+		result
+		, attempts: Number(fs.readFileSync(countFile, 'utf8').trim())
+		, outputFile
+		, workspaceDir
+	};
+}
+
+test('retry-download retries transport failures and publishes atomically', t => {
+	const { result, attempts, outputFile, workspaceDir } = runRetry(
+		t,
+		[
+			'if (( count < 3 )); then'
+			, '\techo "temporary network failure" >&2'
+			, '\texit 6'
+			, 'fi'
+			, 'printf \'downloaded\\n\' > "${output_file}"'
+		].join('\n')
+	);
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.equal(attempts, 3);
+	assert.equal(fs.readFileSync(outputFile, 'utf8'), 'downloaded\n');
+	assert.deepEqual(
+		fs.readdirSync(workspaceDir).filter(name => name.includes('.part.')),
+		[]
+	);
+	assert.match(result.stderr, /retrying in 0 seconds/);
+});
+
+test('retry-download preserves an existing output after exhausted retries', t => {
+	const { result, attempts, outputFile, workspaceDir } = runRetry(
+		t,
+		'printf \'partial\\n\' > "${output_file}"\nexit 7',
+		2,
+		'existing\n'
+	);
+
+	assert.equal(result.status, 7);
+	assert.equal(attempts, 2);
+	assert.equal(fs.readFileSync(outputFile, 'utf8'), 'existing\n');
+	assert.deepEqual(
+		fs.readdirSync(workspaceDir).filter(name => name.includes('.part.')),
+		[]
+	);
+});
+
+test('PECL extension downloads use retry-download', () => {
+	for(const makefile of ['packages/sdl/static.mak', 'packages/libyaml/static.mak'])
+	{
+		const contents = fs.readFileSync(path.join(repoRoot, makefile), 'utf8');
+
+		assert.match(contents, /\/src\/\.github\/bin\/retry-download\.sh https:\/\/pecl\.php\.net\/get\//);
+		assert.doesNotMatch(contents, /wget .*https:\/\/pecl\.php\.net\/get\//);
+	}
+});

--- a/test/embuilder-retry.test.mjs
+++ b/test/embuilder-retry.test.mjs
@@ -1,0 +1,102 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const retryScript = path.join(repoRoot, '.github/bin/retry-embuilder.sh');
+
+function writeExecutable(filePath, contents)
+{
+	fs.writeFileSync(filePath, contents, 'utf8');
+	fs.chmodSync(filePath, 0o755);
+}
+
+function runRetry(t, embuilderBody, maxAttempts = 3)
+{
+	const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'php-wasm-embuilder-retry-'));
+	const binDir = path.join(workspaceDir, 'bin');
+	const countFile = path.join(workspaceDir, 'attempts');
+
+	t.after(() => {
+		fs.rmSync(workspaceDir, { recursive: true, force: true });
+	});
+
+	fs.mkdirSync(binDir, { recursive: true });
+	writeExecutable(
+		path.join(binDir, 'embuilder'),
+		[
+			'#!/usr/bin/env bash'
+			, 'set -euo pipefail'
+			, 'count=0'
+			, 'if [[ -f "${EMBUILDER_TEST_COUNT}" ]]; then'
+			, '\tcount="$(<"${EMBUILDER_TEST_COUNT}")"'
+			, 'fi'
+			, 'count=$((count + 1))'
+			, 'printf \'%s\\n\' "${count}" > "${EMBUILDER_TEST_COUNT}"'
+			, embuilderBody
+			, ''
+		].join('\n')
+	);
+
+	const result = spawnSync('bash', [retryScript, 'build', 'USER'], {
+		cwd: repoRoot
+		, encoding: 'utf8'
+		, env: {
+			...process.env,
+			PATH: `${binDir}:${process.env.PATH ?? ''}`
+			, EMBUILDER_TEST_COUNT: countFile
+			, EMBUILDER_RETRY_ATTEMPTS: String(maxAttempts)
+			, EMBUILDER_RETRY_DELAY_SECONDS: '0'
+		}
+	});
+
+	return {
+		result
+		, attempts: Number(fs.readFileSync(countFile, 'utf8').trim())
+	};
+}
+
+test('retry-embuilder retries transient port download failures', t => {
+	const { result, attempts } = runRetry(
+		t,
+		[
+			'if (( count < 3 )); then'
+			, '\techo "urllib.error.HTTPError: HTTP Error 503: Service Unavailable" >&2'
+			, '\texit 75'
+			, 'fi'
+			, 'echo "embuilder completed"'
+		].join('\n')
+	);
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.equal(attempts, 3);
+	assert.match(result.stdout, /HTTP Error 503/);
+	assert.match(result.stdout, /embuilder completed/);
+	assert.match(result.stderr, /transient embuilder download failure/);
+});
+
+test('retry-embuilder preserves non-transient build failures', t => {
+	const { result, attempts } = runRetry(
+		t,
+		'echo "wasm-ld: error: undefined symbol" >&2\nexit 23'
+	);
+
+	assert.equal(result.status, 23);
+	assert.equal(attempts, 1);
+	assert.match(result.stderr, /non-retryable error/);
+});
+
+test('retry-embuilder stops after the configured number of attempts', t => {
+	const { result, attempts } = runRetry(
+		t,
+		'echo "http.client.RemoteDisconnected: Remote end closed connection without response" >&2\nexit 17'
+	);
+
+	assert.equal(result.status, 17);
+	assert.equal(attempts, 3);
+	assert.match(result.stderr, /failed after 3 attempts/);
+});

--- a/test/embuilder-retry.test.mjs
+++ b/test/embuilder-retry.test.mjs
@@ -8,6 +8,7 @@ import { strict as assert } from 'node:assert';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const retryScript = path.join(repoRoot, '.github/bin/retry-embuilder.sh');
+const sdlMakefile = path.join(repoRoot, 'packages/sdl/static.mak');
 
 function writeExecutable(filePath, contents)
 {
@@ -99,4 +100,18 @@ test('retry-embuilder stops after the configured number of attempts', t => {
 	assert.equal(result.status, 17);
 	assert.equal(attempts, 3);
 	assert.match(result.stderr, /failed after 3 attempts/);
+});
+
+test('SDL port builds use the retry wrapper', () => {
+	const contents = fs.readFileSync(sdlMakefile, 'utf8');
+
+	assert.doesNotMatch(contents, /\$\{DOCKER_RUN\} embuilder build/);
+	assert.match(
+		contents,
+		/\$\{DOCKER_RUN\} retry-embuilder build sdl2 --lto --pic --verbose/
+	);
+	assert.match(
+		contents,
+		/\$\{DOCKER_RUN\} retry-embuilder build libGL-mt-webgl2-ofb-full_es3-getprocaddr --lto --pic --verbose/
+	);
 });

--- a/test/emscripten-cli-entrypoint.test.mjs
+++ b/test/emscripten-cli-entrypoint.test.mjs
@@ -6,6 +6,7 @@ import url from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), '..');
 const cliWrappers = ['source/PhpCliNode.mjs', 'source/PhpCliWeb.mjs'];
+const phpdbgWrappers = ['source/PhpDbgNode.mjs', 'source/PhpDbgWeb.mjs'];
 const phpVersions = ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5'];
 
 test('CLI wrappers call the explicit Emscripten entrypoint with terminated argv', () => {
@@ -20,7 +21,19 @@ test('CLI wrappers call the explicit Emscripten entrypoint with terminated argv'
 	}
 });
 
-test('all supported PHP patches export the CLI entrypoint and return its status', () => {
+test('phpdbg wrappers call the explicit Emscripten entrypoint with terminated argv', () => {
+	for(const wrapper of phpdbgWrappers)
+	{
+		const contents = fs.readFileSync(path.join(repoRoot, wrapper), 'utf8');
+
+		assert.match(contents, /_malloc\(4 \* \(ptrs\.length \+ 1\)\)/, wrapper);
+		assert.match(contents, /setValue\([^\n]+4 \* ptrs\.length, 0, '\*'\)/, wrapper);
+		assert.match(contents, /'wasm_sapi_phpdbg_main'/, wrapper);
+		assert.doesNotMatch(contents, /ccall\(\s*'main'/, wrapper);
+	}
+});
+
+test('all supported PHP patches export explicit CLI and phpdbg entrypoints', () => {
 	for(const version of phpVersions)
 	{
 		const patchFile = `patch/php${version}.patch`;
@@ -35,6 +48,11 @@ test('all supported PHP patches export the CLI entrypoint and return its status'
 		assert.match(
 			contents
 			, /\+int EMSCRIPTEN_KEEPALIVE wasm_sapi_cli_main\(int argc, char \*\*argv\)\n\+\{\n\+\treturn main\(argc, argv\);\n\+\}/
+			, patchFile
+		);
+		assert.match(
+			contents
+			, /-int main\(int argc, char \*\*argv\) \/\* \{\{\{ \*\/\n\+int EMSCRIPTEN_KEEPALIVE wasm_sapi_phpdbg_main\(int argc, char \*\*argv\) \/\* \{\{\{ \*\//
 			, patchFile
 		);
 	}

--- a/test/emscripten-cli-entrypoint.test.mjs
+++ b/test/emscripten-cli-entrypoint.test.mjs
@@ -1,0 +1,41 @@
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import url from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), '..');
+const cliWrappers = ['source/PhpCliNode.mjs', 'source/PhpCliWeb.mjs'];
+const phpVersions = ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5'];
+
+test('CLI wrappers call the explicit Emscripten entrypoint with terminated argv', () => {
+	for(const wrapper of cliWrappers)
+	{
+		const contents = fs.readFileSync(path.join(repoRoot, wrapper), 'utf8');
+
+		assert.match(contents, /_malloc\(4 \* \(ptrs\.length \+ 1\)\)/, wrapper);
+		assert.match(contents, /setValue\([^\n]+4 \* ptrs\.length, 0, '\*'\)/, wrapper);
+		assert.match(contents, /'wasm_sapi_cli_main'/, wrapper);
+		assert.doesNotMatch(contents, /ccall\(\s*'main'/, wrapper);
+	}
+});
+
+test('all supported PHP patches export the CLI entrypoint and return its status', () => {
+	for(const version of phpVersions)
+	{
+		const patchFile = `patch/php${version}.patch`;
+		const contents = fs.readFileSync(path.join(repoRoot, patchFile), 'utf8');
+
+		assert.match(contents, /\+#include <emscripten\.h>/, patchFile);
+		assert.match(
+			contents
+			, /\+#ifdef __EMSCRIPTEN__\n\+\treturn exit_status;\n\+#else\n-\texit\(exit_status\);\n\+\texit\(exit_status\);\n\+#endif/
+			, patchFile
+		);
+		assert.match(
+			contents
+			, /\+int EMSCRIPTEN_KEEPALIVE wasm_sapi_cli_main\(int argc, char \*\*argv\)\n\+\{\n\+\treturn main\(argc, argv\);\n\+\}/
+			, patchFile
+		);
+	}
+});

--- a/test/logical-assignment-transform.test.mjs
+++ b/test/logical-assignment-transform.test.mjs
@@ -1,0 +1,84 @@
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import url from 'node:url';
+import vm from 'node:vm';
+
+const repoRoot = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), '..');
+const transformScript = path.join(repoRoot, 'bin/transform-logical-assignments.mjs');
+const commonJsMakefiles = [
+	'Makefile'
+	, 'packages/php-cgi-wasm/static.mak'
+	, 'packages/php-cli-wasm/static.mak'
+	, 'packages/php-dbg-wasm/static.mak'
+];
+
+const runTransform = inputFile => spawnSync(process.execPath, [transformScript, inputFile], {
+	cwd: repoRoot
+	, encoding: 'utf8'
+});
+
+test('transforms generated logical assignments without duplicating their targets', t => {
+	const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'php-wasm-logical-assignment-'));
+	const inputFile = path.join(workspaceDir, 'runtime.js');
+
+	t.after(() => fs.rmSync(workspaceDir, { recursive: true, force: true }));
+
+	fs.writeFileSync(inputFile, [
+		'let targetReads=0;'
+		, 'const state={};'
+		, 'const holder={get target(){targetReads++;return state;}};'
+		, 'var listeners=holder.target.listeners??=new Set;'
+		, 'let excl;'
+		, '(excl||=[]).push("entry");'
+		, 'const load=name=>import(/* webpackIgnore: true */ name);'
+		, 'require(/* webpackIgnore: true */ "fs");'
+		, 'globalThis.result={targetReads,listeners,stateListeners:state.listeners,excl,load};'
+	].join('\n'), 'utf8');
+
+	const result = runTransform(inputFile);
+	const output = fs.readFileSync(inputFile, 'utf8');
+
+	assert.equal(result.status, 0, result.stderr);
+	assert.doesNotMatch(output, /\?\?=|\|\|=/);
+	assert.match(output, /webpackIgnore: true/);
+	assert.doesNotMatch(output, /var listeners=var listeners=/);
+
+	const context = { require: () => ({}), Set };
+	vm.runInNewContext(output, context);
+
+	assert.equal(context.result.targetReads, 1);
+	assert.equal(context.result.listeners, context.result.stateListeners);
+	assert.equal(context.result.listeners instanceof Set, true);
+	assert.deepEqual([...context.result.excl], ['entry']);
+});
+
+test('leaves the generated runtime untouched when transformation fails', t => {
+	const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'php-wasm-logical-assignment-invalid-'));
+	const inputFile = path.join(workspaceDir, 'runtime.js');
+	const invalidSource = 'var listeners=this.listeners??=;\n';
+
+	t.after(() => fs.rmSync(workspaceDir, { recursive: true, force: true }));
+	fs.writeFileSync(inputFile, invalidSource, 'utf8');
+
+	const result = runTransform(inputFile);
+
+	assert.notEqual(result.status, 0);
+	assert.equal(fs.readFileSync(inputFile, 'utf8'), invalidSource);
+	assert.deepEqual(fs.readdirSync(workspaceDir), ['runtime.js']);
+});
+
+test('all CommonJS build recipes use the syntax-aware transform', () => {
+	for(const makefile of commonJsMakefiles)
+	{
+		const contents = fs.readFileSync(path.join(repoRoot, makefile), 'utf8');
+		const transforms = contents.match(/node bin\/transform-logical-assignments\.mjs \$@/g) ?? [];
+
+		assert.equal(transforms.length, 4, makefile);
+		assert.doesNotMatch(contents, /\\s\*\\\?\\\?=/);
+		assert.doesNotMatch(contents, /\\s\*\\\|\\\|=/);
+	}
+});

--- a/test/logical-assignment-transform.test.mjs
+++ b/test/logical-assignment-transform.test.mjs
@@ -1,5 +1,4 @@
 import { strict as assert } from 'node:assert';
-import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -7,19 +6,15 @@ import { test } from 'node:test';
 import url from 'node:url';
 import vm from 'node:vm';
 
+import { transformLogicalAssignments } from '../bin/transform-logical-assignments.mjs';
+
 const repoRoot = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), '..');
-const transformScript = path.join(repoRoot, 'bin/transform-logical-assignments.mjs');
 const commonJsMakefiles = [
 	'Makefile'
 	, 'packages/php-cgi-wasm/static.mak'
 	, 'packages/php-cli-wasm/static.mak'
 	, 'packages/php-dbg-wasm/static.mak'
 ];
-
-const runTransform = inputFile => spawnSync(process.execPath, [transformScript, inputFile], {
-	cwd: repoRoot
-	, encoding: 'utf8'
-});
 
 test('transforms generated logical assignments without duplicating their targets', t => {
 	const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'php-wasm-logical-assignment-'));
@@ -39,10 +34,9 @@ test('transforms generated logical assignments without duplicating their targets
 		, 'globalThis.result={targetReads,listeners,stateListeners:state.listeners,excl,load};'
 	].join('\n'), 'utf8');
 
-	const result = runTransform(inputFile);
+	transformLogicalAssignments(inputFile);
 	const output = fs.readFileSync(inputFile, 'utf8');
 
-	assert.equal(result.status, 0, result.stderr);
 	assert.doesNotMatch(output, /\?\?=|\|\|=/);
 	assert.match(output, /webpackIgnore: true/);
 	assert.doesNotMatch(output, /var listeners=var listeners=/);
@@ -64,9 +58,7 @@ test('leaves the generated runtime untouched when transformation fails', t => {
 	t.after(() => fs.rmSync(workspaceDir, { recursive: true, force: true }));
 	fs.writeFileSync(inputFile, invalidSource, 'utf8');
 
-	const result = runTransform(inputFile);
-
-	assert.notEqual(result.status, 0);
+	assert.throws(() => transformLogicalAssignments(inputFile));
 	assert.equal(fs.readFileSync(inputFile, 'utf8'), invalidSource);
 	assert.deepEqual(fs.readdirSync(workspaceDir), ['runtime.js']);
 });


### PR DESCRIPTION
## What changed

- pin the Docker builder to the official Emscripten 6.0.6 SDK and carry the remaining `sm-updates` behavior as a local patch
- preserve preload naming, `locateFile` fallbacks, IDBFS modes, duplicate-export handling, and async `dlopen` behavior
- preserve the source -> object -> archive -> side-module path used by dynamic extensions
- link the C++ ABI/runtime required by dynamically loaded ICU libraries and export `HEAPU8` for VRZNO
- keep compiler-rt's profiling runtime out of ordinary `MAIN_MODULE` builds and link it only for instrumented builds
- expose unambiguous CGI, CLI, and phpdbg entrypoints for Emscripten 6, null-terminate CLI/phpdbg `argv`, and return CLI exit statuses without terminating the JS host
- replace regex-based `??=`/`||=` rewriting with a syntax-aware Babel transform for generated CommonJS runtimes
- retry transient Emscripten port and PECL downloads without masking real build failures
- update GD/WebP, iconv, libzip, and Tidy recipes for the current toolchain

## Why

The previous image replaced the SDK checkout with the old `sm-updates` fork. Moving to Emscripten 6 lost local loader and dynamic-linking changes, while new generated-code and entrypoint behavior exposed several assumptions in the PHP wrappers.

In particular, Emscripten 6 renames PHP's argc/argv `main` export while PIB also supplies a no-argument `main`. CLI and phpdbg calls therefore selected PIB's no-op function. Explicit SAPI entrypoints avoid that ambiguity. Emscripten 6 also began emitting logical-assignment expressions whose left-hand sides were corrupted by the old Perl post-processing regex; the AST-based transform preserves them.

The compiler-rt split prevents non-instrumented main modules from creating `default.profraw`, while preserving profile output when instrumentation is explicitly enabled.

## Validation

- built `seanmorris/php-emscripten-builder:latest` locally from the updated Dockerfile
- verified source -> `.o` -> `.a` -> `.so` -> `dlopen` with a side module returning `42`
- verified plain `MAIN_MODULE` produces no profile file and an instrumented build does
- built all six dynamic PHP artifacts in Actions; all dynamic SDL verification jobs passed
- applied the explicit CLI/phpdbg patches cleanly to PHP 8.0 through 8.5
- relinked PHP 8.1 dynamic CLI against the failing CI artifact and passed output, version, and `exit(7)` tests
- incrementally relinked PHP 8.1 dynamic phpdbg with Emscripten 6.0.6, verified the named Wasm export, and passed its real Node prompt/script/quit test
- transformed and syntax-checked eight real Emscripten-generated JS variants from the CI artifact
- ran the repaired CommonJS CGI runtime and passed its hello-world and PHP-version requests
- focused Node regression suite: 13 passed, 0 failed
- focused Deno regression suite: 6 passed, 0 failed
- `git diff --check` passes

Replacement full-matrix CI for the latest commit is in progress.
