### PR TITLE
Clear expired CGI cookies

### DIFF
--- a/source/PhpCgiBase.mjs
+++ b/source/PhpCgiBase.mjs
@@ -70,34 +70,75 @@ class CookieJar
 	 */
 	store(rawCookie)
 	{
-		let name = null;
+		if(!rawCookie || !rawCookie.trim())
+		{
+			return;
+		}
 
 		const cookie = {created: Date.now(), raw: rawCookie};
 
-		const parts = rawCookie.split(';').map(p => p.trim() );
+		const parts = rawCookie.split(';').map(p => p.trim()).filter(Boolean);
 
-		for(const part of parts)
+		if(!parts.length)
+		{
+			return;
+		}
+
+		const [nameValue, ...attributes] = parts;
+		const firstEqual = nameValue.indexOf('=');
+
+		if(firstEqual === -1)
+		{
+			return;
+		}
+
+		cookie.name = nameValue.slice(0, firstEqual);
+		cookie.value = nameValue.slice(firstEqual + 1);
+
+		let expiresAt = null;
+		let hasMaxAge = false;
+
+		for(const part of attributes)
 		{
 			const equal = part.indexOf('=');
 
-			const key   = part.substr(0, equal);
-			const value = part.substr(1 + equal);
+			if(equal === -1)
+			{
+				cookie[part.toLowerCase()] = true;
+				continue;
+			}
+
+			const key   = part.slice(0, equal);
+			const value = part.slice(equal + 1);
 
 			const lowerKey = key.toLowerCase();
 
-			if(!name)
+			if(lowerKey === 'expires')
 			{
-				name = key;
-				cookie.name = key;
-				cookie.value = value;
-			}
-			else if(lowerKey === 'expires')
-			{
-				cookie[lowerKey] = new Date(value).getTime();
+				const parsedExpires = new Date(value).getTime();
+
+				if(Number.isFinite(parsedExpires))
+				{
+					cookie[lowerKey] = parsedExpires;
+
+					if(!hasMaxAge)
+					{
+						expiresAt = parsedExpires;
+					}
+				}
 			}
 			else if(lowerKey === 'max-age')
 			{
-				cookie[lowerKey] = 1000 * Number(value);
+				const parsedMaxAge = Number(value);
+
+				if(Number.isFinite(parsedMaxAge))
+				{
+					hasMaxAge = true;
+					cookie[lowerKey] = 1000 * parsedMaxAge;
+					expiresAt = parsedMaxAge <= 0
+						? cookie.created
+						: cookie.created + cookie[lowerKey];
+				}
 			}
 			else
 			{
@@ -105,14 +146,18 @@ class CookieJar
 			}
 		}
 
-		if(cookie.expires && cookie.created >= cookie.expires)
+		if(expiresAt !== null)
+		{
+			cookie.expiresAt = expiresAt;
+		}
+
+		if(cookie.expiresAt !== undefined && cookie.expiresAt <= cookie.created)
 		{
 			this.cookies.delete(cookie.name);
+			return;
 		}
-		else
-		{
-			this.cookies.set(cookie.name, cookie);
-		}
+
+		this.cookies.set(cookie.name, cookie);
 	}
 
 	/**
@@ -128,13 +173,7 @@ class CookieJar
 
 		for(const cookie of this.cookies.values())
 		{
-			if(cookie.expires && cookie.expires <= now)
-			{
-				this.cookies.delete(cookie.name);
-				continue;
-			}
-
-			if(cookie['max-age'] && cookie['max-age'] >= now - cookie.created)
+			if(cookie.expiresAt !== undefined && cookie.expiresAt <= now)
 			{
 				this.cookies.delete(cookie.name);
 				continue;
@@ -165,7 +204,10 @@ class CookieJar
 	 */
 	load(rawCookies)
 	{
-		rawCookies.trim().split('\n').map(line => this.store(line));
+		for(const line of rawCookies.trim().split('\n').map(line => line.trim()).filter(Boolean))
+		{
+			this.store(line);
+		}
 	}
 
 	/**

--- a/test/cgi-node/cgi-node.test.cjs
+++ b/test/cgi-node/cgi-node.test.cjs
@@ -3,15 +3,55 @@ const { strict: assert } = require('node:assert');
 
 const version = process.env.PHP_VERSION ?? '8.4';
 const baseUrl = `http://127.0.0.1:${Number(process.env.CGI_NODE_TEST_PORT ?? 9001)}/php-wasm/cgi-bin/test`;
+const fetchText = path => fetch(`${baseUrl}/${path}`).then(response => response.text());
+const fetchCookies = async () => JSON.parse(await fetchText('issue53-cookies.php'));
 
 test('renders the CGI hello world demo', async () => {
-	const phpOutput = await (await fetch(`${baseUrl}/hello-world.php`)).text();
+	const phpOutput = await fetchText('hello-world.php');
 
 	assert.equal(phpOutput, 'Hello, world!\n');
 });
 
 test('serves the expected PHP version through CGI', async () => {
-	const phpOutput = await (await fetch(`${baseUrl}/version.php`)).text();
+	const phpOutput = await fetchText('version.php');
 
 	assert.equal(phpOutput, version);
+});
+
+test('retains cookies with a positive Max-Age across requests', async () => {
+	assert.equal(await fetchText('issue53-set-max-age-cookie.php'), 'ttl-set');
+
+	const cookies = await fetchCookies();
+
+	assert.equal(cookies.issue53_ttl, 'keep-me');
+});
+
+test('deletes cookies from request state and the persisted jar', async () => {
+	assert.equal(await fetchText('issue53-set-cookie.php'), 'session-set');
+	assert.equal((await fetchCookies()).issue53_session, 'test-session');
+
+	assert.equal(await fetchText('issue53-delete-cookie.php'), 'session-deleted');
+
+	const cookies = await fetchCookies();
+	const cookieJar = await fetchText('issue53-cookie-jar.php');
+
+	assert.equal(cookies.issue53_session, undefined);
+	assert.doesNotMatch(cookieJar, /issue53_session=/);
+	assert.doesNotMatch(cookieJar, /deleted/);
+});
+
+test('uses the active cookie entry after overwrite and delete cycles', async () => {
+	assert.equal(await fetchText('issue53-set-replace-cookie.php'), 'replace-first');
+	assert.equal((await fetchCookies()).issue53_replace, 'first-value');
+
+	assert.equal(await fetchText('issue53-overwrite-replace-cookie.php'), 'replace-second');
+	assert.equal((await fetchCookies()).issue53_replace, 'second-value');
+
+	assert.equal(await fetchText('issue53-delete-replace-cookie.php'), 'replace-deleted');
+
+	const cookies = await fetchCookies();
+	const cookieJar = await fetchText('issue53-cookie-jar.php');
+
+	assert.equal(cookies.issue53_replace, undefined);
+	assert.doesNotMatch(cookieJar, /issue53_replace=/);
 });

--- a/test/cgi-node/cgi-node.test.mjs
+++ b/test/cgi-node/cgi-node.test.mjs
@@ -3,15 +3,55 @@ import { strict as assert } from 'node:assert';
 
 const version = process.env.PHP_VERSION ?? '8.4';
 const baseUrl = `http://127.0.0.1:${Number(process.env.CGI_NODE_TEST_PORT ?? 9001)}/php-wasm/cgi-bin/test`;
+const fetchText = path => fetch(`${baseUrl}/${path}`).then(response => response.text());
+const fetchCookies = async () => JSON.parse(await fetchText('issue53-cookies.php'));
 
 test('renders the CGI hello world demo', async () => {
-	const phpOutput = await (await fetch(`${baseUrl}/hello-world.php`)).text();
+	const phpOutput = await fetchText('hello-world.php');
 
 	assert.equal(phpOutput, 'Hello, world!\n');
 });
 
 test('serves the expected PHP version through CGI', async () => {
-	const phpOutput = await (await fetch(`${baseUrl}/version.php`)).text();
+	const phpOutput = await fetchText('version.php');
 
 	assert.equal(phpOutput, version);
+});
+
+test('retains cookies with a positive Max-Age across requests', async () => {
+	assert.equal(await fetchText('issue53-set-max-age-cookie.php'), 'ttl-set');
+
+	const cookies = await fetchCookies();
+
+	assert.equal(cookies.issue53_ttl, 'keep-me');
+});
+
+test('deletes cookies from request state and the persisted jar', async () => {
+	assert.equal(await fetchText('issue53-set-cookie.php'), 'session-set');
+	assert.equal((await fetchCookies()).issue53_session, 'test-session');
+
+	assert.equal(await fetchText('issue53-delete-cookie.php'), 'session-deleted');
+
+	const cookies = await fetchCookies();
+	const cookieJar = await fetchText('issue53-cookie-jar.php');
+
+	assert.equal(cookies.issue53_session, undefined);
+	assert.doesNotMatch(cookieJar, /issue53_session=/);
+	assert.doesNotMatch(cookieJar, /deleted/);
+});
+
+test('uses the active cookie entry after overwrite and delete cycles', async () => {
+	assert.equal(await fetchText('issue53-set-replace-cookie.php'), 'replace-first');
+	assert.equal((await fetchCookies()).issue53_replace, 'first-value');
+
+	assert.equal(await fetchText('issue53-overwrite-replace-cookie.php'), 'replace-second');
+	assert.equal((await fetchCookies()).issue53_replace, 'second-value');
+
+	assert.equal(await fetchText('issue53-delete-replace-cookie.php'), 'replace-deleted');
+
+	const cookies = await fetchCookies();
+	const cookieJar = await fetchText('issue53-cookie-jar.php');
+
+	assert.equal(cookies.issue53_replace, undefined);
+	assert.doesNotMatch(cookieJar, /issue53_replace=/);
 });

--- a/test/cgi-node/server.cjs
+++ b/test/cgi-node/server.cjs
@@ -18,6 +18,37 @@ const { nodeRuntimeOptions } = require('../lib/node-runtime-options.cjs');
 	await mkdir(configRoot, { recursive: true });
 	await writeFile(path.join(wwwRoot, 'hello-world.php'), '<?php echo "Hello, world!\\n";');
 	await writeFile(path.join(wwwRoot, 'version.php'), '<?php echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;');
+	await writeFile(path.join(wwwRoot, 'issue53-set-cookie.php'), `<?php
+header('Set-Cookie: issue53_session=test-session; path=/; HttpOnly');
+echo "session-set";
+`);
+	await writeFile(path.join(wwwRoot, 'issue53-set-max-age-cookie.php'), `<?php
+header('Set-Cookie: issue53_ttl=keep-me; Max-Age=60; path=/; HttpOnly');
+echo "ttl-set";
+`);
+	await writeFile(path.join(wwwRoot, 'issue53-set-replace-cookie.php'), `<?php
+header('Set-Cookie: issue53_replace=first-value; path=/; HttpOnly');
+echo "replace-first";
+`);
+	await writeFile(path.join(wwwRoot, 'issue53-overwrite-replace-cookie.php'), `<?php
+header('Set-Cookie: issue53_replace=second-value; path=/; HttpOnly');
+echo "replace-second";
+`);
+	await writeFile(path.join(wwwRoot, 'issue53-delete-cookie.php'), `<?php
+header('Set-Cookie: issue53_session=deleted; expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0; path=/; HttpOnly');
+echo "session-deleted";
+`);
+	await writeFile(path.join(wwwRoot, 'issue53-delete-replace-cookie.php'), `<?php
+header('Set-Cookie: issue53_replace=deleted; expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0; path=/; HttpOnly');
+echo "replace-deleted";
+`);
+	await writeFile(path.join(wwwRoot, 'issue53-cookies.php'), `<?php
+header('Content-Type: application/json');
+echo json_encode($_COOKIE);
+`);
+	await writeFile(path.join(wwwRoot, 'issue53-cookie-jar.php'), `<?php
+echo file_exists('/config/.cookies') ? file_get_contents('/config/.cookies') : '';
+`);
 
 	const php = new PhpCgiNode(nodeRuntimeOptions({
 		version,

--- a/test/cgi-node/server.mjs
+++ b/test/cgi-node/server.mjs
@@ -17,6 +17,37 @@ await mkdir(wwwRoot, { recursive: true });
 await mkdir(configRoot, { recursive: true });
 await writeFile(path.join(wwwRoot, 'hello-world.php'), '<?php echo "Hello, world!\\n";');
 await writeFile(path.join(wwwRoot, 'version.php'), '<?php echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;');
+await writeFile(path.join(wwwRoot, 'issue53-set-cookie.php'), `<?php
+header('Set-Cookie: issue53_session=test-session; path=/; HttpOnly');
+echo "session-set";
+`);
+await writeFile(path.join(wwwRoot, 'issue53-set-max-age-cookie.php'), `<?php
+header('Set-Cookie: issue53_ttl=keep-me; Max-Age=60; path=/; HttpOnly');
+echo "ttl-set";
+`);
+await writeFile(path.join(wwwRoot, 'issue53-set-replace-cookie.php'), `<?php
+header('Set-Cookie: issue53_replace=first-value; path=/; HttpOnly');
+echo "replace-first";
+`);
+await writeFile(path.join(wwwRoot, 'issue53-overwrite-replace-cookie.php'), `<?php
+header('Set-Cookie: issue53_replace=second-value; path=/; HttpOnly');
+echo "replace-second";
+`);
+await writeFile(path.join(wwwRoot, 'issue53-delete-cookie.php'), `<?php
+header('Set-Cookie: issue53_session=deleted; expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0; path=/; HttpOnly');
+echo "session-deleted";
+`);
+await writeFile(path.join(wwwRoot, 'issue53-delete-replace-cookie.php'), `<?php
+header('Set-Cookie: issue53_replace=deleted; expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0; path=/; HttpOnly');
+echo "replace-deleted";
+`);
+await writeFile(path.join(wwwRoot, 'issue53-cookies.php'), `<?php
+header('Content-Type: application/json');
+echo json_encode($_COOKIE);
+`);
+await writeFile(path.join(wwwRoot, 'issue53-cookie-jar.php'), `<?php
+echo file_exists('/config/.cookies') ? file_get_contents('/config/.cookies') : '';
+`);
 
 const php = new PhpCgiNode(nodeRuntimeOptions({
 	version,


### PR DESCRIPTION
## What

- Parse `Set-Cookie` name/value separately from its attributes.
- Track one effective expiration timestamp, with `Max-Age` taking precedence over `Expires`.
- Remove expired or deleted cookies from both the in-memory and persisted cookie jars.
- Add CGI Node coverage for positive `Max-Age`, deletion, and overwrite/delete cycles in ESM and CJS.

## Why

Cookies deleted with `Max-Age=0` could remain persisted and continue to be sent. The duration was compared incorrectly against elapsed time, and the `Expires`/`Max-Age` precedence was not represented correctly.

## Impact

CGI cookie handling now follows `Max-Age` precedence, and expired cookie entries disappear immediately and after reloading the persisted jar.

## Checks

- `PHP_VERSION=8.4 LIB_TYPE=static TEST_FORMAT=mjs bash test/node-cgi-test.sh` — 5 passed.
- Node syntax checks for every modified JS/MJS/CJS file — passed.
- CJS runtime harness deferred to CI because the local checkout does not contain the generated `PhpCgiNode.js` artifact.
